### PR TITLE
Implement BSpline curve evaluation

### DIFF
--- a/adaptivecad/geom/__init__.py
+++ b/adaptivecad/geom/__init__.py
@@ -1,5 +1,6 @@
 """Geometry utilities for AdaptiveCAD."""
 
 from .bezier import BezierCurve
+from .bspline import BSplineCurve
 
-__all__ = ["BezierCurve"]
+__all__ = ["BezierCurve", "BSplineCurve"]

--- a/adaptivecad/geom/bspline.py
+++ b/adaptivecad/geom/bspline.py
@@ -1,0 +1,48 @@
+"""B-spline curve utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from ..linalg import Vec3
+
+
+def _find_span(n: int, degree: int, u: float, knots: List[float]) -> int:
+    """Return knot span index."""
+    if u >= knots[n + 1]:
+        return n
+    if u <= knots[degree]:
+        return degree
+    low = degree
+    high = n + 1
+    mid = (low + high) // 2
+    while u < knots[mid] or u >= knots[mid + 1]:
+        if u < knots[mid]:
+            high = mid
+        else:
+            low = mid
+        mid = (low + high) // 2
+    return mid
+
+
+@dataclass
+class BSplineCurve:
+    control_points: List[Vec3]
+    degree: int
+    knots: List[float]
+
+    def evaluate(self, u: float) -> Vec3:
+        """Evaluate the B-spline curve at parameter u using the de Boor algorithm."""
+        n = len(self.control_points) - 1
+        k = _find_span(n, self.degree, u, self.knots)
+        d = [self.control_points[j] for j in range(k - self.degree, k + 1)]
+        for r in range(1, self.degree + 1):
+            for j in range(self.degree, r - 1, -1):
+                i = k - self.degree + j
+                denom = self.knots[i + self.degree + 1 - r] - self.knots[i]
+                if denom == 0:
+                    alpha = 0.0
+                else:
+                    alpha = (u - self.knots[i]) / denom
+                d[j] = (1 - alpha) * d[j - 1] + alpha * d[j]
+        return d[self.degree]

--- a/adaptivecad/linalg.py
+++ b/adaptivecad/linalg.py
@@ -26,6 +26,8 @@ class Vec3:
     def __mul__(self, scalar: float) -> "Vec3":
         return Vec3(self.x * scalar, self.y * scalar, self.z * scalar)
 
+    __rmul__ = __mul__
+
     def dot(self, other: "Vec3") -> float:
         return self.x * other.x + self.y * other.y + self.z * other.z
 

--- a/tests/test_bspline.py
+++ b/tests/test_bspline.py
@@ -1,0 +1,12 @@
+from adaptivecad.linalg import Vec3
+from adaptivecad.geom import BSplineCurve
+
+
+def test_bspline_evaluate():
+    pts = [Vec3(0.0, 0.0, 0.0), Vec3(1.0, 2.0, 0.0), Vec3(2.0, 0.0, 0.0), Vec3(3.0, 2.0, 0.0)]
+    degree = 2
+    knots = [0.0, 0.0, 0.0, 1.0, 2.0, 2.0, 2.0]
+    curve = BSplineCurve(pts, degree, knots)
+    p = curve.evaluate(1.0)
+    assert abs(p.x - 1.5) < 1e-6
+    assert abs(p.y - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- add a bspline curve implementation using de Boor
- export BSplineCurve from geometry package
- allow scalar multiplication of Vec3 from left hand side
- test bspline evaluation

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d194a6868832f91a6b507ec9ad1f9