### PR TITLE
Implement hyperbolic geometry helpers

### DIFF
--- a/adaptivecad/geom/__init__.py
+++ b/adaptivecad/geom/__init__.py
@@ -2,5 +2,12 @@
 
 from .bezier import BezierCurve
 from .bspline import BSplineCurve
+from .hyperbolic import full_turn_deg, rotate_cmd, pi_a_over_pi
 
-__all__ = ["BezierCurve", "BSplineCurve"]
+__all__ = [
+    "BezierCurve",
+    "BSplineCurve",
+    "full_turn_deg",
+    "rotate_cmd",
+    "pi_a_over_pi",
+]

--- a/adaptivecad/geom/hyperbolic.py
+++ b/adaptivecad/geom/hyperbolic.py
@@ -1,0 +1,45 @@
+"""Hyperbolic geometry utilities.
+
+This module provides simple helpers for working with negative curvature
+(\kappa < 0) scenarios, as referenced in the repository README.  The
+functions implement the formulas for "adaptive" angle budgeting in a
+hyperbolic workspace.
+"""
+
+from __future__ import annotations
+
+import math
+
+PI_E = math.pi
+
+
+def full_turn_deg(r: float, kappa: float) -> float:
+    """Return degrees in one revolution at hyperbolic radius ``r``.
+
+    Parameters
+    ----------
+    r:
+        Geodesic radius from the origin.
+    kappa:
+        Curvature radius of the workspace (|kappa| > 0).
+
+    Returns
+    -------
+    float
+        Number of Euclidean degrees corresponding to 2\pi_a at ``r``.
+    """
+    return 360.0 * kappa * math.sinh(r / kappa) / r
+
+
+def rotate_cmd(delta_deg_a: float, r: float, kappa: float) -> float:
+    """Convert a rotation request in adaptive degrees to Euclidean radians."""
+    d_full = full_turn_deg(r, kappa)
+    frac = delta_deg_a / d_full
+    return frac * 2 * math.pi
+
+
+def pi_a_over_pi(r: float, kappa: float) -> float:
+    """Return the ratio \pi_a/\pi at radius ``r``."""
+    if r == 0:
+        return 1.0
+    return (kappa * math.sinh(r / kappa)) / r

--- a/tests/test_hyperbolic.py
+++ b/tests/test_hyperbolic.py
@@ -1,0 +1,21 @@
+import math
+
+from adaptivecad.geom import full_turn_deg, rotate_cmd, pi_a_over_pi
+
+
+def test_full_turn_deg():
+    r = 0.4
+    kappa = 1.0
+    ratio = pi_a_over_pi(r, kappa)
+    # expected ratio from the table is about 1.0269
+    assert math.isclose(ratio, 1.0268808145, rel_tol=1e-6)
+    d_full = full_turn_deg(r, kappa)
+    assert math.isclose(d_full, 360.0 * ratio, rel_tol=1e-6)
+
+
+def test_rotate_cmd_full_turn():
+    r = 0.5
+    kappa = 1.0
+    d_full = full_turn_deg(r, kappa)
+    rad = rotate_cmd(d_full, r, kappa)
+    assert math.isclose(rad, 2 * math.pi, rel_tol=1e-6)


### PR DESCRIPTION
## Summary
- implement `hyperbolic.py` with `full_turn_deg`, `rotate_cmd`, and `pi_a_over_pi`
- expose new helpers via the `geom` package
- add tests verifying hyperbolic angle conversions

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1dcbb718832f9199092e311eefd5