### PR TITLE
Add GUI playground prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 Below is a *road‑map of the mathematics* you will actually need if you want to write a modern CAD / CAM system completely from scratch and, at the same time, support your **πₐ (“Adaptive Pi”) non‑Euclidean geometry kernel**.
 The list is intentionally grouped as *“modules you will implement”* so you can turn each block into an internal library or namespace.  After each block I give the key formulas, identities, or algorithms you will code, plus notes on typical numerical pitfalls.
 
+
+## AdaptiveCAD Playground
+A lightweight viewer prototype is included in `adaptivecad.gui.playground`.
+Install `PySide6` and `pythonocc-core` and run `python -m adaptivecad.gui.playground`
+to see a simple 3-D demo.
+
 ---
 
 ## 0. Notation conventions used throughout

--- a/adaptivecad/gui/__init__.py
+++ b/adaptivecad/gui/__init__.py
@@ -1,0 +1,1 @@
+"""GUI modules for AdaptiveCAD."""

--- a/adaptivecad/gui/playground.py
+++ b/adaptivecad/gui/playground.py
@@ -1,0 +1,76 @@
+"""Minimal PySide6 + pythonOCC viewer prototype.
+
+This module provides the ``AdaptiveCAD Playground`` application described in
+``README.md``.  It launches a basic 3-D viewer using ``pythonocc-core`` and
+``PySide6``.  The viewer displays a demo scene constructed from the geometric
+primitives available in the package.  It is intentionally lightweight so that
+contributors can quickly run ``python -m adaptivecad.gui.playground`` after
+installing the optional GUI dependencies.
+
+The GUI dependencies are not required for the rest of the package; therefore,
+imports are done lazily with user-friendly error messages if the packages are
+missing.
+"""
+from __future__ import annotations
+
+import sys
+
+
+def _require_gui_modules():
+    """Import optional GUI modules, raising RuntimeError if unavailable."""
+    try:
+        from PySide6.QtWidgets import QApplication, QMainWindow  # type: ignore
+        from OCC.Display.qtDisplay import qtViewer3d  # type: ignore
+    except Exception as exc:  # pragma: no cover - import error path
+        raise RuntimeError(
+            "PySide6 and pythonocc-core are required to run the playground"
+        ) from exc
+    return QApplication, QMainWindow, qtViewer3d
+
+
+def _demo_primitives(display):
+    """Create a demo scene using simple primitives."""
+    try:
+        from adaptivecad import geom, linalg
+    except Exception:  # pragma: no cover - should not happen
+        return
+
+    # Simple demo primitive: a Bezier curve extruded as points
+    curve = geom.BezierCurve([
+        linalg.Vec3(0.0, 0.0, 0.0),
+        linalg.Vec3(25.0, 40.0, 0.0),
+        linalg.Vec3(50.0, 0.0, 0.0),
+    ])
+    pts = [curve.evaluate(u / 20.0) for u in range(21)]
+    for p in pts:
+        display.DisplayShape((p.x, p.y, p.z))
+    display.FitAll()
+
+
+class MainWindow:
+    """Main Playground window."""
+
+    def __init__(self) -> None:
+        QApplication, QMainWindow, qtViewer3d = _require_gui_modules()
+
+        self.app = QApplication(sys.argv)
+        self.win = QMainWindow()
+        self.win.setWindowTitle("AdaptiveCAD – Playground")
+        self.view = qtViewer3d(self.win)
+        self.win.setCentralWidget(self.view)
+        self._setup_demo()
+
+    def _setup_demo(self) -> None:
+        _demo_primitives(self.view._display)
+
+    def run(self) -> None:
+        self.win.show()
+        self.app.exec()
+
+
+def main() -> None:
+    MainWindow().run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,4 @@ authors = [{name="AdaptiveCAD"}]
 description = "Starter modules for AdaptiveCAD"
 requires-python = ">=3.10"
 dependencies = ["numpy>=1.22"]
+optional-dependencies = { gui = ["PySide6", "pythonocc-core"] }

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -1,0 +1,27 @@
+import importlib
+import pytest
+
+
+def test_playground_import():
+    mod = importlib.import_module("adaptivecad.gui.playground")
+    # Expect main import to succeed even without GUI deps
+    assert hasattr(mod, "MainWindow")
+
+
+def test_playground_missing_deps(monkeypatch):
+    import builtins
+
+    calls = []
+    
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("PySide6") or name.startswith("OCC"):
+            raise ImportError("mocked missing")
+        return real_import(name, *args, **kwargs)
+
+    real_import = builtins.__import__
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    mod = importlib.import_module("adaptivecad.gui.playground")
+    with pytest.raises(RuntimeError):
+        mod._require_gui_modules()
+


### PR DESCRIPTION
## Summary
- implement `adaptivecad.gui.playground` with a minimal PySide6/pythonOCC viewer
- expose GUI extras in `pyproject.toml`
- document how to launch the playground in README
- add unit tests for the new GUI module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dfdc8a36c832f9b2f0adb5a19b5c9