### PR TITLE
feat(ui): primitive toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The playground provides an interactive 3D view with the following features:
 - Interactive selection: Click on edges to select and identify shapes
 - Press 'R' to reload the scene during development (useful for quick iterations)
 - Anti-aliased rendering for crisp, clear lines
-- Toolbar with Box, Cylinder and STL export commands
+ - Toolbar with Box, Cylinder and STL/AMA export commands
 
 ## Environment Setup
 

--- a/adaptivecad/commands.py
+++ b/adaptivecad/commands.py
@@ -17,15 +17,24 @@ from typing import Any, Dict, List
 def _require_command_modules():
     """Import optional GUI modules required for command execution."""
     try:
-        from PyQt5.QtWidgets import QInputDialog, QFileDialog
-        from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder
+        from PySide6.QtWidgets import QInputDialog, QFileDialog
+        from OCC.Core.BRepPrimAPI import (
+            BRepPrimAPI_MakeBox,
+            BRepPrimAPI_MakeCylinder,
+        )
         from OCC.Core.StlAPI import StlAPI_Writer
     except Exception as exc:  # pragma: no cover - import error path
         raise RuntimeError(
             "GUI extras not installed. Run:\n   conda install -c conda-forge pythonocc-core pyside6"
         ) from exc
 
-    return QInputDialog, QFileDialog, BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder, StlAPI_Writer
+    return (
+        QInputDialog,
+        QFileDialog,
+        BRepPrimAPI_MakeBox,
+        BRepPrimAPI_MakeCylinder,
+        StlAPI_Writer,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -144,3 +153,31 @@ class ExportStlCmd(BaseCmd):
             mw.win.statusBar().showMessage(f"STL saved ➡ {path}")
         else:
             mw.win.statusBar().showMessage("Failed to save STL")
+
+
+class ExportAmaCmd(BaseCmd):
+    title = "Export AMA"
+
+    def run(self, mw) -> None:  # pragma: no cover - runtime GUI path
+        (
+            _,
+            QFileDialog,
+            _,
+            _,
+            _,
+        ) = _require_command_modules()
+
+        if not DOCUMENT:
+            return
+
+        path, _filter = QFileDialog.getSaveFileName(
+            mw.win, "Save AMA", filter="AMA (*.ama)"
+        )
+        if not path:
+            return
+
+        # Placeholder implementation until AMA writer lands
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("# AMA export coming soon\n")
+
+        mw.win.statusBar().showMessage(f"AMA saved ➡ {path}")

--- a/adaptivecad/gui/playground.py
+++ b/adaptivecad/gui/playground.py
@@ -30,7 +30,12 @@ import sys
 import math
 import numpy as np
 from math import cos, sin, pi
-from adaptivecad.commands import NewBoxCmd, NewCylCmd, ExportStlCmd
+from adaptivecad.commands import (
+    NewBoxCmd,
+    NewCylCmd,
+    ExportStlCmd,
+    ExportAmaCmd,
+)
 
 # Try to import anti-aliasing enum if available
 # Try to import anti-aliasing enum if available
@@ -289,6 +294,7 @@ class MainWindow:
         _add_action("Cylinder", "media-optical", NewCylCmd)
         tb.addSeparator()
         _add_action("Export STL", "document-save", ExportStlCmd)
+        _add_action("Export AMA", "document-save-as", ExportAmaCmd)
 
         self._build_demo()
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,13 +7,14 @@ def test_commands_import():
     mod = importlib.import_module("adaptivecad.commands")
     assert hasattr(mod, "Feature")
     assert hasattr(mod, "NewBoxCmd")
+    assert hasattr(mod, "ExportAmaCmd")
 
 
 def test_commands_missing_deps(monkeypatch):
     real_import = builtins.__import__
 
     def fake(name, *args, **kwargs):
-        if name.startswith("PyQt5") or name.startswith("OCC"):
+        if name.startswith("PySide6") or name.startswith("OCC"):
             raise ImportError("mocked missing")
         return real_import(name, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- add Export AMA placeholder command
- show AMA option in the playground toolbar
- migrate commands to PySide6 widgets
- update README bullet list
- test presence of ExportAmaCmd

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6dd22a98832fb5baa05b6bd26c82