### PR TITLE
Add ND vector and optional imports

### DIFF
--- a/adaptivecad/__init__.py
+++ b/adaptivecad/__init__.py
@@ -1,1 +1,10 @@
-from .gcode_generator import generate_gcode_from_shape, generate_gcode_from_ama_file, generate_gcode_from_ama_data
+try:
+    from .gcode_generator import (
+        generate_gcode_from_shape,
+        generate_gcode_from_ama_file,
+        generate_gcode_from_ama_data,
+    )
+except ModuleNotFoundError:
+    # Optional dependencies like pythonocc-core may be missing in some
+    # environments. Allow importing submodules that don't require OCC.
+    pass

--- a/adaptivecad/commands.py
+++ b/adaptivecad/commands.py
@@ -11,12 +11,19 @@ package can be used without installing ``pythonocc-core`` or ``PyQt``.
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-from adaptivecad.io.ama_writer import write_ama
 from adaptivecad.io.gcode_generator import ama_to_gcode, SimpleMilling
 from adaptivecad.gcode_generator import generate_gcode_from_shape
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder
-from OCC.Core.TopoDS import TopoDS_Shape
+
+# Optional OCC imports for geometry creation
+try:
+    from OCC.Core.gp import gp_Pnt
+    from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeBox, BRepPrimAPI_MakeCylinder
+    from OCC.Core.TopoDS import TopoDS_Shape
+except Exception:  # pragma: no cover - OCC not installed
+    gp_Pnt = None
+    BRepPrimAPI_MakeBox = None
+    BRepPrimAPI_MakeCylinder = None
+    TopoDS_Shape = object
 
 # ---------------------------------------------------------------------------
 # Optional GUI helpers
@@ -184,6 +191,8 @@ class ExportAmaCmd(BaseCmd):
         if not path:
             return
 
+        from adaptivecad.io.ama_writer import write_ama  # lazy import
+
         write_ama(DOCUMENT, path)
         mw.win.statusBar().showMessage(f"AMA saved ➡ {path}")
 
@@ -208,8 +217,10 @@ class ExportGCodeCmd(BaseCmd):
         # First, we need to save as AMA temporarily
         with tempfile.NamedTemporaryFile(suffix=".ama", delete=False) as tmp_ama:
             tmp_ama_path = tmp_ama.name
-        
+
         # Write the current document to the temporary AMA file
+        from adaptivecad.io.ama_writer import write_ama  # lazy import
+
         write_ama(DOCUMENT, tmp_ama_path)
         
         # Ask for G-code settings

--- a/adaptivecad/gcode_generator.py
+++ b/adaptivecad/gcode_generator.py
@@ -1,7 +1,13 @@
 # adaptivecad/gcode_generator.py
 import datetime
 from typing import List
-from OCC.Core.TopoDS import TopoDS_Shape # For type hinting
+
+# Optional type hint if pythonocc-core is installed
+try:
+    from OCC.Core.TopoDS import TopoDS_Shape  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    TopoDS_Shape = object  # fallback placeholder
+
 from .io.ama_reader import read_ama, AMAFile
 
 def generate_gcode_from_ama_data(ama_file: AMAFile, tool_diameter: float = 6.0) -> str:

--- a/adaptivecad/gui/playground.py
+++ b/adaptivecad/gui/playground.py
@@ -64,7 +64,7 @@ from adaptivecad.commands import (
 from adaptivecad.snapping import SnapManager, GridStrategy
 from adaptivecad.push_pull import PushPullFeatureCmd # Added PushPull
 
-from PySide6.QtCore import Qt # Added for Qt.Key_Return etc.
+# Qt and OCC imports are optional and loaded lazily
 
 # Try to import anti-aliasing enum if available
 AA_AVAILABLE = False
@@ -74,8 +74,11 @@ try:
 except ImportError:
     pass
 
-from OCC.Core.TopoDS import TopoDS_Face # For type checking selected face
-from OCC.Core.AIS import AIS_Shape # For checking selected object type
+try:
+    from OCC.Core.TopoDS import TopoDS_Face  # For type checking selected face
+    from OCC.Core.AIS import AIS_Shape  # For checking selected object type
+except Exception:  # pragma: no cover - OCC optional
+    TopoDS_Face = AIS_Shape = object  # type: ignore
 
 
 # Property helper for volume

--- a/adaptivecad/io/__init__.py
+++ b/adaptivecad/io/__init__.py
@@ -1,3 +1,10 @@
-from .ama_writer import write_ama
+"""IO utilities for AdaptiveCAD."""
+
 from .ama_reader import read_ama, AMAFile, AMAPart
 from .gcode_generator import ama_to_gcode, GCodeGenerator, SimpleMilling
+
+# AMA writing relies on pythonocc-core. Import if available.
+try:
+    from .ama_writer import write_ama
+except Exception:  # OCC not installed or missing deps
+    write_ama = None

--- a/adaptivecad/linalg.py
+++ b/adaptivecad/linalg.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import math
 from typing import Iterable, List
+import numpy as np
 
 
 @dataclass
@@ -114,3 +115,50 @@ def polar_decompose(m: Matrix4) -> tuple[Matrix4, Matrix4]:
     rot = Matrix4([list(R[i]) + [0.0] for i in range(3)] + [[0.0, 0.0, 0.0, 1.0]])
     stretch = Matrix4([list(S[i]) + [0.0] for i in range(3)] + [[0.0, 0.0, 0.0, 1.0]])
     return rot, stretch
+
+
+class VecN:
+    """Simple N-dimensional vector built on NumPy arrays."""
+
+    def __init__(self, coords: Iterable[float]):
+        self.coords = np.asarray(list(coords), dtype=float)
+
+    def __repr__(self) -> str:
+        return f"VecN({self.coords.tolist()})"
+
+    def __len__(self) -> int:
+        return int(self.coords.size)
+
+    def __iter__(self):
+        return iter(self.coords)
+
+    def __add__(self, other: "VecN") -> "VecN":
+        if self.coords.size != other.coords.size:
+            raise ValueError("Dimension mismatch")
+        return VecN(self.coords + other.coords)
+
+    def __sub__(self, other: "VecN") -> "VecN":
+        if self.coords.size != other.coords.size:
+            raise ValueError("Dimension mismatch")
+        return VecN(self.coords - other.coords)
+
+    def __mul__(self, scalar: float) -> "VecN":
+        return VecN(self.coords * scalar)
+
+    __rmul__ = __mul__
+
+    def dot(self, other: "VecN") -> float:
+        if self.coords.size != other.coords.size:
+            raise ValueError("Dimension mismatch")
+        return float(np.dot(self.coords, other.coords))
+
+    def norm(self) -> float:
+        return float(np.linalg.norm(self.coords))
+
+    def dist(self, other: "VecN") -> float:
+        if self.coords.size != other.coords.size:
+            raise ValueError("Dimension mismatch")
+        return float(np.linalg.norm(self.coords - other.coords))
+
+    def dim(self) -> int:
+        return int(self.coords.size)

--- a/adaptivecad/push_pull.py
+++ b/adaptivecad/push_pull.py
@@ -1,15 +1,26 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
-from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_MakeOffsetShape
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakePrism
-from OCC.Core.TopoDS import TopoDS_Face, TopoDS_Shape
-from OCC.Core.gp import gp_Vec, gp_Dir
-from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Fuse, BRepAlgoAPI_Cut
-from OCC.Core.TopExp import TopExp_Explorer
-from OCC.Core.TopAbs import TopAbs_FACE
-from OCC.Core.BRepAdaptor import BRepAdaptor_Surface
-from OCC.Core.GeomAbs import GeomAbs_Plane, GeomAbs_Cylinder
+try:
+    from OCC.Core.BRepOffsetAPI import BRepOffsetAPI_MakeOffsetShape
+    from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakePrism
+    from OCC.Core.TopoDS import TopoDS_Face, TopoDS_Shape
+    from OCC.Core.gp import gp_Vec, gp_Dir
+    from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Fuse, BRepAlgoAPI_Cut
+    from OCC.Core.TopExp import TopExp_Explorer
+    from OCC.Core.TopAbs import TopAbs_FACE
+    from OCC.Core.BRepAdaptor import BRepAdaptor_Surface
+    from OCC.Core.GeomAbs import GeomAbs_Plane, GeomAbs_Cylinder
+except Exception:  # pragma: no cover - OCC optional
+    BRepOffsetAPI_MakeOffsetShape = None
+    BRepPrimAPI_MakePrism = None
+    TopoDS_Face = TopoDS_Shape = object  # type: ignore
+    gp_Vec = gp_Dir = None
+    BRepAlgoAPI_Fuse = BRepAlgoAPI_Cut = None
+    TopExp_Explorer = None
+    TopAbs_FACE = None
+    BRepAdaptor_Surface = None
+    GeomAbs_Plane = GeomAbs_Cylinder = None
 
 from adaptivecad.commands import BaseCmd, Feature, DOCUMENT, rebuild_scene
 

--- a/adaptivecad/snapping.py
+++ b/adaptivecad/snapping.py
@@ -1,6 +1,13 @@
-from OCC.Core.gp import gp_Pnt
-from OCC.Core.AIS import AIS_Point
-from OCC.Display.OCCViewer import Viewer3d
+from typing import Any
+
+try:
+    from OCC.Core.gp import gp_Pnt
+    from OCC.Core.AIS import AIS_Point
+    from OCC.Display.OCCViewer import Viewer3d
+except Exception:  # pragma: no cover - OCC not installed
+    gp_Pnt = Any  # type: ignore
+    AIS_Point = Any  # type: ignore
+    Viewer3d = Any  # type: ignore
 
 class SnapStrategy:
     def __init__(self, viewer_display):

--- a/tests/test_vecn.py
+++ b/tests/test_vecn.py
@@ -1,0 +1,20 @@
+import numpy as np
+from adaptivecad.linalg import VecN
+
+
+def test_vecn_basic_ops():
+    a = VecN([1.0, 2.0, 3.0, 4.0])
+    b = VecN([4.0, 3.0, 2.0, 1.0])
+    c = a + b
+    assert np.allclose(c.coords, np.array([5.0, 5.0, 5.0, 5.0]))
+    assert np.isclose(a.dot(b), 20.0)
+    assert np.isclose(a.norm(), np.sqrt(30.0))
+    assert np.isclose(a.dist(b), np.linalg.norm(a.coords - b.coords))
+    assert a.dim() == 4
+
+
+def test_vecn_iter_len_repr():
+    v = VecN([1, 2, 3])
+    assert list(v) == [1.0, 2.0, 3.0]
+    assert len(v) == 3
+    assert repr(v) == "VecN([1.0, 2.0, 3.0])"


### PR DESCRIPTION
## Summary
- introduce `VecN` for generic vector math
- add tests for `VecN`
- guard optional OCC and PySide6 imports across modules
- ensure playground and commands load without GUI deps
- enhance `VecN` with iteration and repr

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e93943994832f8be29982a76b0578