### PR TITLE
Improve snap controls and viewcube placement

### DIFF
--- a/adaptivecad/commands.py
+++ b/adaptivecad/commands.py
@@ -122,6 +122,11 @@ def rebuild_scene(display) -> None:
                 consumed.add(target)
             elif isinstance(target, str) and target.isdigit():
                 consumed.add(int(target))
+            tool = feat.params.get("tool")
+            if isinstance(tool, int):
+                consumed.add(tool)
+            elif isinstance(tool, str) and tool.isdigit():
+                consumed.add(int(tool))
     # Only display features not consumed by a later feature
     for i, feat in enumerate(DOCUMENT):
         if i not in consumed:

--- a/adaptivecad/gui/playground.py
+++ b/adaptivecad/gui/playground.py
@@ -312,8 +312,8 @@ class SettingsDialog:
         # ...existing code...
 class MainWindow:
     def resizeEvent(self, event):
-        if hasattr(self, "viewcube"):
-            self.viewcube.move(self.win.width() - 100, 10)
+        if hasattr(self, "_position_viewcube"):
+            self._position_viewcube()
         super(type(self.win), self.win).resizeEvent(event)
     def add_view_toolbar(self):
         from PySide6.QtGui import QAction
@@ -354,6 +354,17 @@ class MainWindow:
         self.property_dock.setWidget(self.property_widget)
         self.win.addDockWidget(Qt.LeftDockWidgetArea, self.property_dock)
         self.property_dock.setVisible(True)
+
+    def _build_snap_menu(self):
+        snap_menu = self.win.menuBar().addMenu("Snaps")
+        self.snap_actions = {}
+        for _, strat in self.snap_manager.strategies:
+            name = strat.__name__
+            act = QAction(name.replace('_', ' ').title(), self.win, checkable=True)
+            act.setChecked(self.snap_manager.is_enabled(name))
+            act.toggled.connect(lambda checked, n=name: self.snap_manager.enable_strategy(n, checked))
+            snap_menu.addAction(act)
+            self.snap_actions[name] = act
 
     def _show_properties(self, obj):
         from PySide6.QtWidgets import QLabel, QLineEdit, QHBoxLayout
@@ -496,9 +507,17 @@ class MainWindow:
         self.view.show() # Explicitly show the view
 
         # --- Add View Cube overlay ---
-        self.viewcube = ViewCubeWidget(self.view._display, self.win)
-        self.viewcube.move(self.win.width() - 100, 10)
+        self.viewcube = ViewCubeWidget(self.view._display, self.view)
+        self._position_viewcube()
         self.viewcube.show()
+
+        # Reposition cube on view resize
+        original_resize = self.view.resizeEvent
+        def resizeEvent(evt):
+            if original_resize:
+                original_resize(evt)
+            self._position_viewcube()
+        self.view.resizeEvent = resizeEvent
 
         # Add menu toggle for View Cube
         viewcube_action = QAction("Show View Cube", self.win, checkable=True)
@@ -517,6 +536,7 @@ class MainWindow:
         self.snap_manager.register(endpoint_snap, priority=20)
         self.snap_manager.register(grid_snap, priority=10)
         self.current_snap_point = None
+        self._build_snap_menu()
 
         # Override mouse events instead of connecting to signals that don't exist
         # Override the qtViewer3d's mouse event handlers
@@ -737,6 +757,10 @@ class MainWindow:
         if hasattr(self, 'view') and self.view is not None and hasattr(self.view, '_display'):
             _demo_primitives(self.view._display)
 
+    def _position_viewcube(self):
+        if hasattr(self, 'viewcube') and self.viewcube.parent() is self.view:
+            self.viewcube.move(self.view.width() - self.viewcube.width() - 10, 10)
+
     def _on_mouse_press(self, x, y, buttons, modifiers):
         if self.current_mode == "PushPull" and self.push_pull_cmd:
             if not self.push_pull_cmd.selected_face: # If no face is selected yet for PP
@@ -823,8 +847,10 @@ class MainWindow:
         pass # On mouse click: use self.current_snap_point for placement
 
     def toggle_grid_snap(self):
-        self.snap_manager.toggle()
-        status_message = f"Snapping: {'ON' if self.snap_manager.enabled else 'OFF'}"
+        is_on = self.snap_manager.toggle_strategy('grid_snap')
+        if hasattr(self, 'snap_actions') and 'grid_snap' in self.snap_actions:
+            self.snap_actions['grid_snap'].setChecked(is_on)
+        status_message = f"Grid Snap {'ON' if is_on else 'OFF'}"
         self.win.statusBar().showMessage(status_message, 2000)
 
     def enter_push_pull_mode(self):

--- a/adaptivecad/snap.py
+++ b/adaptivecad/snap.py
@@ -3,18 +3,35 @@ import numpy as np
 class SnapManager:
     def __init__(self, tol_px=12):
         self.strategies = []
+        self.strategy_enabled = {}
         self.tol_px = tol_px  # screen-space tolerance (pixels)
         self.enabled = True   # master snap toggle
 
     def register(self, strategy, priority=0):
         self.strategies.append((priority, strategy))
         self.strategies.sort(reverse=True)
+        self.strategy_enabled[strategy.__name__] = True
+
+    def enable_strategy(self, name: str, enabled: bool = True) -> None:
+        if name in self.strategy_enabled:
+            self.strategy_enabled[name] = enabled
+
+    def toggle_strategy(self, name: str) -> bool:
+        if name in self.strategy_enabled:
+            self.strategy_enabled[name] = not self.strategy_enabled[name]
+            return self.strategy_enabled[name]
+        return False
+
+    def is_enabled(self, name: str) -> bool:
+        return self.strategy_enabled.get(name, False)
 
     def snap(self, world_pt, view):
         if not self.enabled:
             return None, None
         best, best_dist, best_label = None, float('inf'), None
         for _, strat in self.strategies:
+            if not self.strategy_enabled.get(strat.__name__, True):
+                continue
             result = strat(world_pt, view)
             if result is not None:
                 pt, label = result


### PR DESCRIPTION
## Summary
- track consumed boolean tools when rebuilding scene
- allow enabling/disabling snap strategies
- add snap strategy menu in GUI
- keep ViewCube within viewer and reposition on resize
- toggle grid snap strategy via `G` shortcut

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'OCC')*

------
https://chatgpt.com/codex/tasks/task_e_684ed1d02bec832f975e429b7ebd05bf