### PR TITLE
Enhance primitives and property UI

### DIFF
--- a/adaptivecad/commands.py
+++ b/adaptivecad/commands.py
@@ -718,3 +718,26 @@ class NewTorusCmd(BaseCmd):
         shape = make_torus(center, maj, minr)
         DOCUMENT.append(Feature("Torus", dict(center=center, major_radius=maj, minor_radius=minr), shape))
         rebuild_scene(mw.view._display)
+
+class NewConeCmd(BaseCmd):
+    title = "Cone"
+
+    def run(self, mw):
+        from PySide6.QtWidgets import QInputDialog
+        from adaptivecad.primitives import make_cone
+        center_str, ok = QInputDialog.getText(mw.win, "Cone Center", "Center (x,y,z):", text="0,0,0")
+        if not ok:
+            return
+        center = [float(x) for x in center_str.split(",")]
+        r1, ok = QInputDialog.getDouble(mw.win, "Base Radius", "Base radius:", 10.0)
+        if not ok:
+            return
+        r2, ok = QInputDialog.getDouble(mw.win, "Top Radius", "Top radius:", 0.0)
+        if not ok:
+            return
+        height, ok = QInputDialog.getDouble(mw.win, "Height", "Height:", 20.0)
+        if not ok:
+            return
+        shape = make_cone(center, r1, r2, height)
+        DOCUMENT.append(Feature("Cone", dict(center=center, base_radius=r1, top_radius=r2, height=height), shape))
+        rebuild_scene(mw.view._display)

--- a/adaptivecad/gui/playground.py
+++ b/adaptivecad/gui/playground.py
@@ -19,6 +19,7 @@ else:
     from adaptivecad.commands import (
         NewBoxCmd, NewCylCmd, ExportStlCmd, ExportAmaCmd, ExportGCodeCmd, ExportGCodeDirectCmd,
         MoveCmd, UnionCmd, CutCmd, NewNDBoxCmd, NewNDFieldCmd, NewBezierCmd, NewBSplineCmd,
+        NewBallCmd, NewTorusCmd, NewConeCmd,
         rebuild_scene, DOCUMENT
     )
     # Optional anti-aliasing support
@@ -223,13 +224,14 @@ class MainWindow:
             act.triggered.connect(make_slot(fn))
             tb.addAction(act)
         self.views_toolbar = tb
-    def clear_property_panel(self):
-        # Clear all widgets from the property panel
+    def clear_property_panel(self, show_placeholder=True):
+        """Remove all widgets from the property panel."""
         for i in reversed(range(self.property_layout.count())):
             widget = self.property_layout.itemAt(i).widget()
             if widget:
                 widget.setParent(None)
-        self.property_layout.addWidget(QLabel("No selection."))
+        if show_placeholder:
+            self.property_layout.addWidget(QLabel("No selection."))
 
     def _init_property_panel(self):
         from PySide6.QtWidgets import QDockWidget, QWidget, QVBoxLayout, QLabel
@@ -256,11 +258,8 @@ class MainWindow:
 
     def _show_properties(self, obj):
         from PySide6.QtWidgets import QLabel, QLineEdit, QHBoxLayout
-        # Clear previous
-        for i in reversed(range(self.property_layout.count())):
-            widget = self.property_layout.itemAt(i).widget()
-            if widget:
-                widget.setParent(None)
+        # Clear previous widgets
+        self.clear_property_panel(show_placeholder=False)
         self.property_layout.addWidget(QLabel(f"Type: {type(obj).__name__}"))
         # Show editable attributes (simple, non-callable, non-private)
         def is_editable(val):
@@ -631,7 +630,9 @@ class MainWindow:
         add_shape_action("B-spline Curve", "curve-b-spline", NewBSplineCmd)
         add_shape_action("ND Box", "view-list-details", NewNDBoxCmd)
         add_shape_action("ND Field", "view-list-tree", NewNDFieldCmd)
-        # (Ball and Torus omitted for now)
+        add_shape_action("Ball", "media-record", NewBallCmd)
+        add_shape_action("Torus", "preferences-desktop-theme", NewTorusCmd)
+        add_shape_action("Cone", "media-eject", NewConeCmd)
         shapes_btn = QToolButton(self.win)
         shapes_btn.setText("Shapes")
         shapes_btn.setIcon(QIcon.fromTheme("view-cube"))
@@ -690,6 +691,7 @@ class MainWindow:
         """Build or rebuild the demo scene."""
         if hasattr(self, 'view') and self.view is not None and hasattr(self.view, '_display'):
             _demo_primitives(self.view._display)
+        self.clear_property_panel()
 
     def _position_viewcube(self):
         if hasattr(self, 'viewcube') and self.viewcube.parent() is self.view:

--- a/adaptivecad/primitives.py
+++ b/adaptivecad/primitives.py
@@ -1,5 +1,9 @@
 from OCC.Core.gp import gp_Pnt, gp_Ax2, gp_Dir
-from OCC.Core.BRepPrimAPI import BRepPrimAPI_MakeSphere, BRepPrimAPI_MakeTorus
+from OCC.Core.BRepPrimAPI import (
+    BRepPrimAPI_MakeSphere,
+    BRepPrimAPI_MakeTorus,
+    BRepPrimAPI_MakeCone,
+)
 
 def make_ball(center, radius):
     c = gp_Pnt(*center)
@@ -9,3 +13,9 @@ def make_torus(center, major_radius, minor_radius, axis=(0,0,1)):
     c = gp_Pnt(*center)
     ax = gp_Ax2(c, gp_Dir(*axis))
     return BRepPrimAPI_MakeTorus(ax, major_radius, minor_radius).Shape()
+
+def make_cone(center, radius1, radius2, height, axis=(0,0,1)):
+    """Create a truncated cone shape."""
+    c = gp_Pnt(*center)
+    ax = gp_Ax2(c, gp_Dir(*axis))
+    return BRepPrimAPI_MakeCone(ax, radius1, radius2, height).Shape()


### PR DESCRIPTION
## Summary
- add `make_cone` helper
- expose Cone creation command and menu entries for Ball, Torus and Cone
- reset property panel when building demo and when showing properties

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f56086318832f937cebd895d25df4