### PR TITLE
Add analytic B-rep slicer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ examples and unit tests without a large toolchain.  Current features include:
 - `adaptivecad.geom` – Bézier and B‑spline curves plus hyperbolic helpers
 - `adaptivecad.io` – AMA reader/writer utilities
 - `adaptivecad.gcode_generator` – placeholder G‑code generation routines
+- `adaptivecad.analytic_slicer` – helper for analytic B‑rep slicing
 - `adaptivecad.gui.playground` – PySide6 viewer with a toolbar for Box,
   Cylinder, Bézier and B‑spline curves, push‑pull editing and export commands
   (STL, AMA and G‑code)

--- a/adaptivecad/analytic_slicer.py
+++ b/adaptivecad/analytic_slicer.py
@@ -1,0 +1,41 @@
+"""Analytic B-rep slicing helpers."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def slice_brep_for_layer(shape: Any, z: float):
+    """Return the intersection of ``shape`` with a horizontal plane.
+
+    Parameters
+    ----------
+    shape:
+        ``TopoDS_Shape`` instance to slice.
+    z:
+        Height of the slicing plane in model units.
+
+    Returns
+    -------
+    Any
+        The intersection edges as a ``TopoDS_Shape``.
+
+    Notes
+    -----
+    This function requires ``pythonocc-core``. If the package is not
+    installed, :class:`ImportError` is raised when the function is called.
+    """
+    try:
+        from OCC.Core.BRepAlgoAPI import BRepAlgoAPI_Section
+        from OCC.Core.gp import gp_Pln, gp_Ax3, gp_Dir, gp_Pnt
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise ImportError("pythonocc-core is required for analytic slicing") from exc
+
+    plane = gp_Pln(gp_Ax3(gp_Pnt(0, 0, z), gp_Dir(0, 0, 1)))
+    section = BRepAlgoAPI_Section(shape, plane)
+    section.ComputePCurveOn1(True)
+    section.Approximation(True)
+    section.Build()
+    return section.Shape()
+
+
+__all__ = ["slice_brep_for_layer"]

--- a/tests/test_analytic_slicer.py
+++ b/tests/test_analytic_slicer.py
@@ -1,0 +1,19 @@
+import importlib
+import pytest
+
+
+@pytest.fixture
+def occ_installed():
+    try:
+        import OCC.Core  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def test_slice_requires_occ(occ_installed):
+    if occ_installed:
+        pytest.skip("OCC present; this test checks missing dependency")
+    from adaptivecad import analytic_slicer
+    with pytest.raises(ImportError):
+        analytic_slicer.slice_brep_for_layer(None, 0.0)


### PR DESCRIPTION
## Summary
- add `analytic_slicer.slice_brep_for_layer` helper for OCC based slicing
- document analytic slicer in the README
- test ImportError when OCC isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f58da554c832f86f395c94b50771c