### PR TITLE
Add expression-based param system

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ After the first AI generation, drag the sliders in the dialog to resize or
 tune α/μ without re‑prompting OpenAI. Every change re‑solves constraints and
 updates the body in real time.
 
+## Parametric Dimensions
+AdaptiveCAD now includes a lightweight parameter system. Define variables in a
+``ParamEnv`` and use them in feature parameters:
+
+```python
+from adaptivecad import ParamEnv
+
+env = ParamEnv()
+env.set('x', 20)
+env.set('theta', 45)
+
+box = Feature("Box", {"l": "x", "w": "10+5*sin(theta)", "h": 30}, shape=None)
+length = box.eval_param('l', env)
+```
+
+Expressions may reference standard ``math`` functions and ``numpy`` via ``np``.
+
 ## Environment Setup
 
 ### Using Conda (recommended)

--- a/adaptivecad/__init__.py
+++ b/adaptivecad/__init__.py
@@ -4,7 +4,10 @@ __all__ = [
     "generate_gcode_from_shape",
     "generate_gcode_from_ama_file",
     "generate_gcode_from_ama_data",
+    "ParamEnv",
 ]
+
+from .params import ParamEnv
 
 
 def generate_gcode_from_shape(*args, **kwargs):

--- a/adaptivecad/commands.py
+++ b/adaptivecad/commands.py
@@ -11,6 +11,8 @@ package can be used without installing ``pythonocc-core`` or ``PyQt``.
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
+from adaptivecad.params import ParamEnv
+
 from adaptivecad.gcode_generator import generate_gcode_from_shape
 
 try:  # Optional OCC dependency
@@ -83,6 +85,19 @@ class Feature:
             self.local_transform = np.asarray(self.local_transform)
         if self.children is None:
             self.children = []
+
+    def eval_param(self, key, env: 'ParamEnv'):
+        """Evaluate a parameter as a possible expression using ``env``."""
+        val = self.params.get(key)
+        if isinstance(val, (int, float)):
+            return val
+        if isinstance(val, str):
+            try:
+                return env.eval(val)
+            except Exception:
+                print(f"Error evaluating param {key}: {val}")
+                return 0
+        return val
 
     def set_parent(self, parent):
         if self.parent is not None and self in self.parent.children:

--- a/adaptivecad/params.py
+++ b/adaptivecad/params.py
@@ -1,0 +1,29 @@
+import math
+import numpy as np
+
+class ParamEnv:
+    """Registry for named parameters and math constants."""
+
+    def __init__(self):
+        self.vars = {}
+        self.constants = {k: getattr(math, k) for k in dir(math) if not k.startswith("_")}
+        # Common math shorthands
+        self.constants.update({
+            'pi': math.pi,
+            'e': math.e,
+            'sin': math.sin,
+            'cos': math.cos,
+            'tan': math.tan,
+            'sqrt': math.sqrt,
+        })
+        self.constants.update({'np': np})
+
+    def set(self, name, value):
+        self.vars[name] = value
+
+    def get(self, name):
+        return self.vars.get(name, self.constants.get(name))
+
+    def eval(self, expr):
+        env = {**self.constants, **self.vars}
+        return eval(expr, {"__builtins__": {}}, env)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,0 +1,20 @@
+import math
+from adaptivecad.params import ParamEnv
+from adaptivecad.commands import Feature
+
+
+def test_param_env_basic():
+    env = ParamEnv()
+    env.set('x', 10)
+    env.set('theta', 45)
+    assert env.eval('x + 5') == 15
+    val = env.eval('sin(theta)')
+    assert math.isclose(val, math.sin(45), rel_tol=1e-9)
+
+
+def test_feature_eval_param():
+    env = ParamEnv()
+    env.set('x', 3)
+    feat = Feature('Box', {'l': '2*x', 'w': 5}, shape=None)
+    assert feat.eval_param('l', env) == 6
+    assert feat.eval_param('w', env) == 5


### PR DESCRIPTION
## Summary
- implement `ParamEnv` for variables and expression evaluation
- enable expression parameters on `Feature`
- export `ParamEnv` from the package
- document the new functionality in README
- add unit test covering parameter evaluation

## Testing
- `pip install numpy`
- `pip install sympy`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f59cc8790832fb0e4074cb7ff03f0