### PR TITLE
Add Revolve tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The playground provides an interactive 3D view with the following features:
 - Interactive selection: Click on edges to select and identify shapes
 - Press 'R' to reload the scene during development (useful for quick iterations)
 - Anti-aliased rendering for crisp, clear lines
-- Toolbar with Box, Cylinder, Bézier and B‑spline curve creation,
+- Toolbar with Box, Cylinder, **Revolve**, Bézier and B‑spline curve creation,
   push‑pull editing, and export commands (STL, AMA and G‑code)
 - View mode toolbar to toggle Shaded, Wireframe and Hidden‑Line views
 

--- a/adaptivecad/commands.py
+++ b/adaptivecad/commands.py
@@ -835,3 +835,47 @@ class NewConeCmd(BaseCmd):
         shape = make_cone(center, r1, r2, height)
         DOCUMENT.append(Feature("Cone", dict(center=center, base_radius=r1, top_radius=r2, height=height), shape))
         rebuild_scene(mw.view._display)
+
+class RevolveCmd(BaseCmd):
+    title = "Revolve"
+
+    def run(self, mw):
+        from PySide6.QtWidgets import QInputDialog
+        from adaptivecad.primitives import make_revolve
+
+        curve_items = [
+            f"{i}: {feat.name}" for i, feat in enumerate(DOCUMENT) if hasattr(feat, "shape")
+        ]
+        if not curve_items:
+            mw.win.statusBar().showMessage("No profile curves found!")
+            return
+
+        idx, ok = QInputDialog.getItem(mw.win, "Revolve", "Select profile curve:", curve_items, 0, False)
+        if not ok:
+            return
+        curve_idx = int(idx.split(":")[0])
+        profile = DOCUMENT[curve_idx].shape
+
+        axis_origin_str, ok = QInputDialog.getText(mw.win, "Axis Origin", "Axis origin (x,y,z):", text="0,0,0")
+        if not ok:
+            return
+        axis_origin = [float(x) for x in axis_origin_str.split(",")]
+
+        axis_dir_str, ok = QInputDialog.getText(mw.win, "Axis Direction", "Axis direction (dx,dy,dz):", text="0,0,1")
+        if not ok:
+            return
+        axis_dir = [float(x) for x in axis_dir_str.split(",")]
+
+        angle_deg, ok = QInputDialog.getDouble(mw.win, "Angle", "Degrees:", 360.0, 1.0, 360.0)
+        if not ok:
+            return
+
+        shape = make_revolve(profile, axis_origin, axis_dir, angle_deg)
+        DOCUMENT.append(
+            Feature(
+                "Revolve",
+                dict(profile=curve_idx, axis_origin=axis_origin, axis_dir=axis_dir, angle=angle_deg),
+                shape,
+            )
+        )
+        rebuild_scene(mw.view._display)

--- a/adaptivecad/gui/playground.py
+++ b/adaptivecad/gui/playground.py
@@ -33,6 +33,7 @@ else:
         NewBallCmd,
         NewTorusCmd,
         NewConeCmd,
+        RevolveCmd,
         ScaleCmd,
         rebuild_scene,
         DOCUMENT,
@@ -830,6 +831,7 @@ class MainWindow:
         add_shape_action("Ball", "media-record", NewBallCmd)
         add_shape_action("Torus", "preferences-desktop-theme", NewTorusCmd)
         add_shape_action("Cone", "media-eject", NewConeCmd)
+        add_shape_action("Revolve", "object-rotate-right", RevolveCmd)
         shapes_btn = QToolButton(self.win)
         shapes_btn.setText("Shapes")
         shapes_btn.setIcon(QIcon.fromTheme("view-cube"))

--- a/adaptivecad/primitives.py
+++ b/adaptivecad/primitives.py
@@ -3,7 +3,9 @@ from OCC.Core.BRepPrimAPI import (
     BRepPrimAPI_MakeSphere,
     BRepPrimAPI_MakeTorus,
     BRepPrimAPI_MakeCone,
+    BRepPrimAPI_MakeRevol,
 )
+import math
 
 def make_ball(center, radius):
     c = gp_Pnt(*center)
@@ -19,3 +21,9 @@ def make_cone(center, radius1, radius2, height, axis=(0,0,1)):
     c = gp_Pnt(*center)
     ax = gp_Ax2(c, gp_Dir(*axis))
     return BRepPrimAPI_MakeCone(ax, radius1, radius2, height).Shape()
+
+def make_revolve(profile, axis_point, axis_dir=(0,0,1), angle_deg=360):
+    """Revolve a profile edge/wire about an axis to create a solid."""
+    ax = gp_Ax2(gp_Pnt(*axis_point), gp_Dir(*axis_dir))
+    angle_rad = math.radians(angle_deg)
+    return BRepPrimAPI_MakeRevol(profile, ax, angle_rad).Shape()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,6 +8,7 @@ def test_commands_import():
     assert hasattr(mod, "Feature")
     assert hasattr(mod, "NewBoxCmd")
     assert hasattr(mod, "ExportAmaCmd")
+    assert hasattr(mod, "RevolveCmd")
 
 
 def test_commands_missing_deps(monkeypatch):


### PR DESCRIPTION
## Summary
- add `make_revolve` helper
- implement `RevolveCmd` command
- expose the command in the GUI toolbar
- document Revolve in README
- test import of `RevolveCmd`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7296bddc832fbbeb239eb874021a