### PR TITLE
Implement Snap Menu with 2D snap points

### DIFF
--- a/adaptivecad/commands.py
+++ b/adaptivecad/commands.py
@@ -194,6 +194,15 @@ class Feature:
             points.append(self.get_reference_point())
         return points
 
+    def snap_points_2d(self):
+        """Return common 2‑D snap points based on feature parameters."""
+        from adaptivecad.snap_points import snap_points_2d as util
+
+        try:
+            return util(self)
+        except Exception:
+            return []
+
     def apply_translation(self, delta):
         from adaptivecad.nd_math import translationN
         import numpy as np

--- a/adaptivecad/gui/playground.py
+++ b/adaptivecad/gui/playground.py
@@ -583,12 +583,24 @@ class MainWindow:
 
         viewcube_action.triggered.connect(toggle_cube)
         self.win.menuBar().addAction(viewcube_action)
-        self._init_property_panel()  # Initialize SnapManager
+        self._init_property_panel()  # Initialize property dock
+        from PySide6.QtCore import Qt
+        from adaptivecad.gui.snap_menu import SnapMenu
+        self.snap_menu = SnapMenu(self)
+        self.win.addDockWidget(Qt.RightDockWidgetArea, self.snap_menu)
+        # Initialize SnapManager
         from adaptivecad.snap import SnapManager
-        from adaptivecad.snap_strategies import grid_snap, endpoint_snap
+        from adaptivecad.snap_strategies import (
+            grid_snap,
+            endpoint_snap,
+            midpoint_snap,
+            center_snap,
+        )
 
         self.snap_manager = SnapManager()
         self.snap_manager.register(endpoint_snap, priority=20)
+        self.snap_manager.register(midpoint_snap, priority=15)
+        self.snap_manager.register(center_snap, priority=15)
         self.snap_manager.register(grid_snap, priority=10)
         self.current_snap_point = None
         # Note: Snap tolerance slider will be added in the run method
@@ -1074,6 +1086,14 @@ class MainWindow:
         slider_layout.addWidget(label)
         slider_layout.addWidget(slider)
         self.property_layout.addLayout(slider_layout)
+
+    def update_snap_points_display(self):
+        """Refresh the viewer when snap settings change."""
+        if hasattr(self.view, "_display"):
+            try:
+                self.view._display.Context.UpdateCurrentViewer()
+            except Exception:
+                pass
 
     def _on_snap_tolerance_changed(self, value, label):
         """Update snap tolerance when the slider is moved"""

--- a/adaptivecad/gui/snap_menu.py
+++ b/adaptivecad/gui/snap_menu.py
@@ -1,0 +1,31 @@
+from PySide6.QtWidgets import QDockWidget, QCheckBox, QVBoxLayout, QWidget
+from PySide6.QtCore import Qt
+
+from adaptivecad.snap_points import SNAP_TYPES
+
+class SnapMenu(QDockWidget):
+    """Dock widget with check boxes to toggle snap types."""
+
+    def __init__(self, mainwin):
+        super().__init__("Snap Types")
+        self.mainwin = mainwin
+        widget = QWidget()
+        layout = QVBoxLayout()
+        self.checks = {}
+        for name in SNAP_TYPES:
+            cb = QCheckBox(name)
+            cb.setChecked(SNAP_TYPES[name])
+            cb.stateChanged.connect(self._make_toggler(name))
+            layout.addWidget(cb)
+            self.checks[name] = cb
+        layout.addStretch(1)
+        widget.setLayout(layout)
+        self.setWidget(widget)
+        self.setFloating(False)
+
+    def _make_toggler(self, name):
+        def f(state):
+            SNAP_TYPES[name] = bool(state)
+            if hasattr(self.mainwin, "update_snap_points_display"):
+                self.mainwin.update_snap_points_display()
+        return f

--- a/adaptivecad/snap_points.py
+++ b/adaptivecad/snap_points.py
@@ -1,0 +1,37 @@
+SNAP_TYPES = {
+    "Endpoint": True,
+    "Midpoint": True,
+    "Center": True,
+}
+
+
+def snap_points_2d(feature):
+    """Return list of (point, type) snap candidates for simple features."""
+    points = []
+    params = getattr(feature, "params", {})
+    name = getattr(feature, "name", "")
+    if name == "Box":
+        l = float(params.get("l", 1))
+        w = float(params.get("w", 1))
+        z = float(params.get("z", 0))
+        corners = [[0, 0, z], [l, 0, z], [l, w, z], [0, w, z]]
+        if SNAP_TYPES.get("Endpoint", False):
+            points += [(pt, "Endpoint") for pt in corners]
+        if SNAP_TYPES.get("Midpoint", False):
+            mids = [[l/2, 0, z], [l, w/2, z], [l/2, w, z], [0, w/2, z]]
+            points += [(pt, "Midpoint") for pt in mids]
+        if SNAP_TYPES.get("Center", False):
+            points.append(([l/2, w/2, z], "Center"))
+    elif name == "Line":
+        p1, p2 = params.get("points", ([0, 0, 0], [0, 0, 0]))
+        if SNAP_TYPES.get("Endpoint", False):
+            points.append((p1, "Endpoint"))
+            points.append((p2, "Endpoint"))
+        if SNAP_TYPES.get("Midpoint", False):
+            mid = [(p1[i] + p2[i]) / 2 for i in range(len(p1))]
+            points.append((mid, "Midpoint"))
+    elif name in ("Cyl", "Circle"):
+        center = params.get("center", [0, 0, 0])
+        if SNAP_TYPES.get("Center", False):
+            points.append((center, "Center"))
+    return points

--- a/adaptivecad/snap_strategies.py
+++ b/adaptivecad/snap_strategies.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from adaptivecad.snap_points import SNAP_TYPES
+
 def grid_snap(world_pt, view):
     s = getattr(view, 'grid_spacing', 10.0)  # Default grid spacing if not set
     snapped = np.round(np.array(world_pt) / s) * s
@@ -14,4 +16,30 @@ def endpoint_snap(world_pt, view):
                 d = np.linalg.norm(np.array(pt) - np.array(world_pt))
                 if d < getattr(view, 'snap_world_tol', 1e-3):
                     return (np.array(pt), "◆")  # ◆ for endpoint
+    return None
+
+
+def midpoint_snap(world_pt, view):
+    from adaptivecad.commands import DOCUMENT
+    for feat in DOCUMENT:
+        if hasattr(feat, 'snap_points_2d'):
+            for pt, typ in feat.snap_points_2d():
+                if typ != 'Midpoint':
+                    continue
+                d = np.linalg.norm(np.array(pt) - np.array(world_pt))
+                if d < getattr(view, 'snap_world_tol', 1e-3):
+                    return (np.array(pt), '●')
+    return None
+
+
+def center_snap(world_pt, view):
+    from adaptivecad.commands import DOCUMENT
+    for feat in DOCUMENT:
+        if hasattr(feat, 'snap_points_2d'):
+            for pt, typ in feat.snap_points_2d():
+                if typ != 'Center':
+                    continue
+                d = np.linalg.norm(np.array(pt) - np.array(world_pt))
+                if d < getattr(view, 'snap_world_tol', 1e-3):
+                    return (np.array(pt), '◎')
     return None


### PR DESCRIPTION
## Summary
- add `SnapMenu` dock widget for enabling snap types
- implement `snap_points_2d` helper and expose from `Feature`
- provide midpoint and center snap strategies
- register new strategies in playground and dock the new snap menu
- include small viewer refresh helper for snap toggles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f73b06074832fbcdc4df0ae18ad6e