### PR TITLE
Improve snapping and command exports

### DIFF
--- a/adaptivecad/commands/__init__.py
+++ b/adaptivecad/commands/__init__.py
@@ -1,1 +1,63 @@
-from ..command_defs import BaseCmd, Feature, DOCUMENT, rebuild_scene
+"""Convenience exports for command classes used in the GUI playground."""
+
+from ..command_defs import (
+    BaseCmd,
+    Feature,
+    DOCUMENT,
+    rebuild_scene,
+    NewBoxCmd,
+    ExportAmaCmd,
+    RevolveCmd,
+    ExportStlCmd,
+    ExportGCodeCmd,
+    ExportGCodeDirectCmd,
+    MoveCmd,
+    UnionCmd,
+    CutCmd,
+    ScaleCmd,
+    NewNDBoxCmd,
+    NewNDFieldCmd,
+    NewBezierCmd,
+    NewBSplineCmd,
+    NewBallCmd,
+    NewTorusCmd,
+    NewConeCmd,
+    _require_command_modules,
+)
+
+try:
+    from .pi_square_cmd import PiSquareCmd
+    from .draped_sheet_cmd import DrapedSheetCmd
+except Exception:  # optional OCC deps may be missing
+    PiSquareCmd = None
+    DrapedSheetCmd = None
+
+__all__ = [
+    "BaseCmd",
+    "Feature",
+    "DOCUMENT",
+    "rebuild_scene",
+    "NewBoxCmd",
+    "ExportAmaCmd",
+    "ExportStlCmd",
+    "ExportGCodeCmd",
+    "ExportGCodeDirectCmd",
+    "RevolveCmd",
+    "MoveCmd",
+    "ScaleCmd",
+    "UnionCmd",
+    "CutCmd",
+    "NewNDBoxCmd",
+    "NewNDFieldCmd",
+    "NewBezierCmd",
+    "NewBSplineCmd",
+    "NewBallCmd",
+    "NewTorusCmd",
+    "NewConeCmd",
+    "_require_command_modules",
+]
+
+if PiSquareCmd is not None:
+    __all__.append("PiSquareCmd")
+if DrapedSheetCmd is not None:
+    __all__.append("DrapedSheetCmd")

--- a/adaptivecad/gui/playground.py
+++ b/adaptivecad/gui/playground.py
@@ -722,6 +722,8 @@ class MainWindow:
         )
 
         self.snap_manager = SnapManager()
+        # world-space tolerance for snap strategies
+        self.snap_world_tol = 0.5
         self.snap_manager.register(endpoint_snap, priority=20)
         self.snap_manager.register(midpoint_snap, priority=15)
         self.snap_manager.register(center_snap, priority=15)

--- a/adaptivecad/snap.py
+++ b/adaptivecad/snap.py
@@ -29,17 +29,36 @@ class SnapManager:
     def is_enabled(self, name: str) -> bool:
         return self.strategy_enabled.get(name, False)
 
+    def _screen_coords(self, view, pt):
+        """Project a 3‑D point to screen coordinates using the viewer."""
+        try:
+            if hasattr(pt, "X"):
+                x, y, z = float(pt.X()), float(pt.Y()), float(pt.Z())
+            else:
+                x, y, z = float(pt[0]), float(pt[1]), float(pt[2])
+            if (
+                hasattr(view, "_display")
+                and hasattr(view._display, "View")
+                and hasattr(view._display.View, "Project")
+            ):
+                return np.array(view._display.View.Project(x, y, z))
+        except Exception:
+            pass
+        return np.array([x, y])
+
     def snap(self, world_pt, view):
         if not self.enabled:
             return None, None
-        best, best_dist, best_label = None, float('inf'), None
+        best, best_dist, best_label = None, float("inf"), None
         for _, strat in self.strategies:
             if not self.strategy_enabled.get(strat.__name__, True):
                 continue
             result = strat(world_pt, view)
             if result is not None:
                 pt, label = result
-                d = np.linalg.norm(view.world_to_screen(pt) - view.world_to_screen(world_pt))
+                d = np.linalg.norm(
+                    self._screen_coords(view, pt) - self._screen_coords(view, world_pt)
+                )
                 if d < self.tol_px and d < best_dist:
                     best, best_dist, best_label = pt, d, label
         return (best, best_label) if best is not None else (None, None)


### PR DESCRIPTION
## Summary
- refine SnapManager to project points to screen
- expose world snap tolerance in playground
- re-export command classes in `adaptivecad.commands`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fa98b181c832f8969ef155ac8c4be