### PR TITLE
Add placeholder for 5‑axis adaptive clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ Your πₐ kernel generalises Euclidean distance by allowing *location‑depende
 4. Stub **CAM waterline** strategy first (2‑axis) to close the CAD–CAM loop quickly.
 5. Integrate **πₐ metric** gradually: start with read‑only viewer, then allow geodesic queries, finally constraint‑driven updates.
 6. Layer more aggressive CAM (adaptive clearing, 5‑axis) only after core kernels are numerically rock‑solid.
+7. The module `adaptivecad.cam.adaptive_clearing_5axis` is a placeholder
+   that raises ``NotImplementedError`` until those kernels are verified.
 
 ---
 

--- a/adaptivecad/cam/__init__.py
+++ b/adaptivecad/cam/__init__.py
@@ -6,3 +6,24 @@ from ..linalg import Vec3
 def linear_toolpath(points):
     """Generate a simple linear toolpath from a list of points."""
     return [Vec3(p.x, p.y, p.z) for p in points]
+
+
+def adaptive_clearing_5axis(shape, tool_radius: float = 3.0):
+    """Placeholder for aggressive 5-axis adaptive clearing.
+
+    This stub exists so downstream modules can import the API, but the
+    actual implementation is intentionally deferred until the numerical
+    kernels (linalg and geometry) are thoroughly validated.
+
+    Args:
+        shape: CAD shape to machine. The type is intentionally loose
+            because this function is not implemented yet.
+        tool_radius (float): Radius of the milling tool in millimeters.
+
+    Raises:
+        NotImplementedError: Always, until the kernel stack is stable.
+    """
+
+    raise NotImplementedError(
+        "Adaptive clearing for 5-axis machines is not implemented yet"
+    )

--- a/tests/test_cam.py
+++ b/tests/test_cam.py
@@ -1,0 +1,6 @@
+import pytest
+from adaptivecad.cam import adaptive_clearing_5axis
+
+def test_adaptive_clearing_not_implemented():
+    with pytest.raises(NotImplementedError):
+        adaptive_clearing_5axis(None)


### PR DESCRIPTION
## Summary
- provide `adaptive_clearing_5axis` stub in `adaptivecad.cam`
- note stub in project README build order
- test that the stub raises `NotImplementedError`

## Testing
- `pip install numpy`
- `pip install sympy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68509731f914832f95d53ce6e00afd18