### PR TITLE
Add πₐ viewer and geodesic utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ The playground provides an interactive 3D view with the following features:
   push‑pull editing, and export commands (STL, AMA and G‑code)
 - View mode toolbar to toggle Shaded, Wireframe and Hidden‑Line views
 
+### πₐ Viewer and geodesic tools
+Run `python -m adaptivecad.gui.pi_a_viewer` for a read‑only demonstration of the πₐ metric. This mode disables editing commands so you can inspect imported shapes. Geometry queries use `adaptivecad.geom.geodesic_distance` to measure hyperbolic separation. Higher level algorithms can move points toward targets via `HyperbolicConstraint` for constraint‑driven updates.
+
 ### Live parameter editing
-After the first AI generation, drag the sliders in the dialog to resize or
-tune α/μ without re‑prompting OpenAI. Every change re‑solves constraints and
-updates the body in real time.
+After the first AI generation, drag the sliders in the dialog to resize or tune α/μ without re‑prompting OpenAI. Every change re‑solves constraints and updates the body in real time.
 
 ## Parametric Dimensions
 AdaptiveCAD now includes a lightweight parameter system. Define variables in a

--- a/adaptivecad/geom/__init__.py
+++ b/adaptivecad/geom/__init__.py
@@ -11,3 +11,12 @@ __all__ = [
     "rotate_cmd",
     "pi_a_over_pi",
 ]
+from .hyperbolic import geodesic_distance, move_towards, HyperbolicConstraint
+
+__all__.extend(
+    [
+        "geodesic_distance",
+        "move_towards",
+        "HyperbolicConstraint",
+    ]
+)

--- a/adaptivecad/geom/hyperbolic.py
+++ b/adaptivecad/geom/hyperbolic.py
@@ -43,3 +43,54 @@ def pi_a_over_pi(r: float, kappa: float) -> float:
     if r == 0:
         return 1.0
     return (kappa * math.sinh(r / kappa)) / r
+
+
+def geodesic_distance(
+    p1: tuple[float, float, float], p2: tuple[float, float, float], kappa: float
+) -> float:
+    """Return the πₐ geodesic distance between ``p1`` and ``p2``."""
+    r1 = math.sqrt(p1[0] ** 2 + p1[1] ** 2 + p1[2] ** 2)
+    r2 = math.sqrt(p2[0] ** 2 + p2[1] ** 2 + p2[2] ** 2)
+    if r1 == 0:
+        return r2
+    if r2 == 0:
+        return r1
+    dot = p1[0] * p2[0] + p1[1] * p2[1] + p1[2] * p2[2]
+    cos_theta = max(min(dot / (r1 * r2), 1.0), -1.0)
+    cosh_val = (
+        math.cosh(r1 / kappa) * math.cosh(r2 / kappa)
+        - math.sinh(r1 / kappa) * math.sinh(r2 / kappa) * cos_theta
+    )
+    cosh_val = max(cosh_val, 1.0)
+    return kappa * math.acosh(cosh_val)
+
+
+def move_towards(
+    p: tuple[float, float, float],
+    target: tuple[float, float, float],
+    kappa: float,
+    step: float,
+) -> tuple[float, float, float]:
+    """Move ``p`` towards ``target`` along the hyperbolic geodesic by ``step``."""
+    dist = geodesic_distance(p, target, kappa)
+    if dist == 0 or step <= 0:
+        return p
+    frac = min(step / dist, 1.0)
+    return (
+        p[0] + frac * (target[0] - p[0]),
+        p[1] + frac * (target[1] - p[1]),
+        p[2] + frac * (target[2] - p[2]),
+    )
+
+
+class HyperbolicConstraint:
+    """Constraint that drags a point toward a target using the πₐ metric."""
+
+    def __init__(self, target: tuple[float, float, float], kappa: float):
+        self.target = target
+        self.kappa = kappa
+
+    def update(
+        self, point: tuple[float, float, float], step: float = 0.1
+    ) -> tuple[float, float, float]:
+        return move_towards(point, self.target, self.kappa, step)

--- a/adaptivecad/gui/pi_a_viewer.py
+++ b/adaptivecad/gui/pi_a_viewer.py
@@ -1,0 +1,27 @@
+"""Minimal read-only viewer demonstrating the πₐ metric."""
+
+from __future__ import annotations
+
+try:
+    from PySide6.QtWidgets import QApplication
+    from .playground import MainWindow, HAS_GUI
+except Exception:  # pragma: no cover - optional GUI deps missing
+    HAS_GUI = False
+
+
+def main() -> None:  # pragma: no cover - GUI integration
+    """Launch the read-only viewer if GUI libraries are available."""
+    if not HAS_GUI:
+        raise RuntimeError("PySide6 not available")
+
+    app = QApplication([])
+    mw = MainWindow()
+    if hasattr(mw, "main_toolbar"):
+        mw.main_toolbar.setDisabled(True)
+    mw.win.setWindowTitle("πₐ Viewer")
+    mw.win.show()
+    app.exec()
+
+
+if __name__ == "__main__":  # pragma: no cover - script mode
+    main()

--- a/tests/test_pi_a.py
+++ b/tests/test_pi_a.py
@@ -1,0 +1,18 @@
+import math
+from adaptivecad.geom import geodesic_distance, HyperbolicConstraint
+
+
+def test_geodesic_distance_origin():
+    p1 = (0.0, 0.0, 0.0)
+    p2 = (1.0, 0.0, 0.0)
+    d = geodesic_distance(p1, p2, 1.0)
+    assert math.isclose(d, 1.0, rel_tol=1e-6)
+
+
+def test_constraint_update():
+    cons = HyperbolicConstraint((1.0, 0.0, 0.0), 1.0)
+    p = (0.0, 0.0, 0.0)
+    p_new = cons.update(p, step=0.5)
+    assert geodesic_distance(p_new, cons.target, 1.0) < geodesic_distance(
+        p, cons.target, 1.0
+    )

--- a/tests/test_pi_a_viewer.py
+++ b/tests/test_pi_a_viewer.py
@@ -1,0 +1,23 @@
+import importlib
+import pytest
+
+
+def test_pi_a_viewer_import():
+    mod = importlib.import_module("adaptivecad.gui.pi_a_viewer")
+    assert hasattr(mod, "main")
+
+
+def test_pi_a_viewer_missing_deps(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("PySide6"):
+            raise ImportError("mocked missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    mod = importlib.import_module("adaptivecad.gui.pi_a_viewer")
+    with pytest.raises(RuntimeError):
+        mod.main()


### PR DESCRIPTION
## Summary
- implement hyperbolic geodesic helpers and constraint update
- expose new utilities from `adaptivecad.geom`
- add `pi_a_viewer` script for read-only inspection
- document πₐ viewer and utilities in README
- test geodesic distance, constraint update and viewer import

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685097255594832fbff5886b85f49b71