### PR TITLE
Add waterline CAM stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ examples and unit tests without a large toolchain.  Current features include:
 - `adaptivecad.geom` – Bézier and B‑spline curves plus hyperbolic helpers
 - `adaptivecad.io` – AMA reader/writer utilities
 - `adaptivecad.gcode_generator` – placeholder G‑code generation routines
+  including `SimpleMilling` and a stub `WaterlineMilling` strategy
 - `adaptivecad.analytic_slicer` – helper for analytic B‑rep slicing
 - `adaptivecad.gui.playground` – PySide6 viewer with a toolbar for Box,
   Cylinder, Bézier and B‑spline curves, push‑pull editing and export commands
@@ -296,7 +297,7 @@ Your πₐ kernel generalises Euclidean distance by allowing *location‑depende
 1. Finish **linalg** + **geom.curve** so you can load/author sketches.
 2. Implement **sketch solver** (least‑squares) → export DXF to verify.
 3. Add **surface & solid B‑rep** with Euler operators.
-4. Stub **CAM waterline** strategy first (2‑axis) to close the CAD–CAM loop quickly.
+4. Stub **CAM waterline** strategy first (2‑axis) to close the CAD–CAM loop quickly. *(Implemented as `WaterlineMilling`)*
 5. Integrate **πₐ metric** gradually: start with read‑only viewer, then allow geodesic queries, finally constraint‑driven updates.
 6. Layer more aggressive CAM (adaptive clearing, 5‑axis) only after core kernels are numerically rock‑solid.
 

--- a/adaptivecad/io/__init__.py
+++ b/adaptivecad/io/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "ama_to_gcode",
     "GCodeGenerator",
     "SimpleMilling",
+    "WaterlineMilling",
 ]
 
 
@@ -44,3 +45,8 @@ def GCodeGenerator(*args, **kwargs):  # type: ignore
 def SimpleMilling(*args, **kwargs):  # type: ignore
     from .gcode_generator import SimpleMilling
     return SimpleMilling(*args, **kwargs)
+
+
+def WaterlineMilling(*args, **kwargs):  # type: ignore
+    from .gcode_generator import WaterlineMilling
+    return WaterlineMilling(*args, **kwargs)

--- a/adaptivecad/io/gcode_generator.py
+++ b/adaptivecad/io/gcode_generator.py
@@ -262,6 +262,51 @@ class SimpleMilling(GCodeGenerator):
         program.add_footer()
         return program
 
+
+class WaterlineMilling(GCodeGenerator):
+    """Stub 2‑axis waterline strategy."""
+
+    def __init__(
+        self,
+        safe_height: float = 10.0,
+        step_down: float = 1.0,
+        total_depth: float = 5.0,
+        feed_rate: float = 100.0,
+        rapid_feed_rate: float = 500.0,
+        tool_diameter: float = 3.0,
+    ) -> None:
+        self.safe_height = safe_height
+        self.step_down = step_down
+        self.total_depth = total_depth
+        self.feed_rate = feed_rate
+        self.rapid_feed_rate = rapid_feed_rate
+        self.tool_diameter = tool_diameter
+
+    def generate(self, part_data) -> GCodeProgram:
+        """Generate a basic waterline toolpath."""
+
+        program = GCodeProgram(name=f"waterline_{part_data.get('name', 'part')}")
+        program.add_header()
+        program.add_comment("Waterline milling operation (stub)")
+        program.add_comment(f"Tool diameter: {self.tool_diameter}mm")
+
+        size = 50
+        depth = 0.0
+        while depth < self.total_depth - 1e-6:
+            depth = min(depth + self.step_down, self.total_depth)
+            # Rapid to safe height and start position
+            program.add_command(GCodeRapidMove(z=self.safe_height, comment="Move to safe height"))
+            program.add_command(GCodeRapidMove(x=0, y=0, comment="Move to start position"))
+            program.add_command(GCodeLinearMove(z=-depth, f=self.feed_rate / 2, comment="Move to cutting depth"))
+            program.add_command(GCodeLinearMove(x=size, f=self.feed_rate, comment="Cut along X"))
+            program.add_command(GCodeLinearMove(y=size, comment="Cut along Y"))
+            program.add_command(GCodeLinearMove(x=0, comment="Cut back along X"))
+            program.add_command(GCodeLinearMove(y=0, comment="Cut back along Y"))
+
+        program.add_command(GCodeRapidMove(z=self.safe_height, comment="Move to safe height"))
+        program.add_footer()
+        return program
+
 def ama_to_gcode(ama_file_path: str, output_path: str = None, strategy: GCodeGenerator = None) -> str:
     """
     Convert an AMA file to G-code.

--- a/ama2gcode.py
+++ b/ama2gcode.py
@@ -5,13 +5,13 @@ AMA to G-code converter utility
 This script converts an AMA (Adaptive Manufacturing Archive) file to G-code for CNC machining.
 
 Usage:
-    ama2gcode.py input.ama [output.gcode] [--strategy=simple] [--safe-height=10]
+    ama2gcode.py input.ama [output.gcode] [--strategy=simple|waterline] [--safe-height=10]
                 [--cut-depth=1] [--feed-rate=100] [--tool-diameter=3]
 
 Options:
     input.ama           Input AMA file path
     output.gcode        Output G-code file path (default is input filename with .gcode extension)
-    --strategy          Milling strategy: 'simple' (default)
+    --strategy          Milling strategy: 'simple' or 'waterline'
     --safe-height       Safe height for rapid movements in mm (default: 10.0)
     --cut-depth         Depth of cut in mm (default: 1.0)
     --feed-rate         Feed rate in mm/min (default: 100.0)
@@ -21,14 +21,14 @@ Options:
 import os
 import sys
 import argparse
-from adaptivecad.io import ama_to_gcode, SimpleMilling
+from adaptivecad.io import ama_to_gcode, SimpleMilling, WaterlineMilling
 
 def main():
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Convert AMA file to G-code')
     parser.add_argument('input', help='Input AMA file path')
     parser.add_argument('output', nargs='?', default=None, help='Output G-code file path (default: input filename with .gcode extension)')
-    parser.add_argument('--strategy', default='simple', choices=['simple'], help='Milling strategy')
+    parser.add_argument('--strategy', default='simple', choices=['simple', 'waterline'], help='Milling strategy')
     parser.add_argument('--safe-height', type=float, default=10.0, help='Safe height for rapid movements in mm')
     parser.add_argument('--cut-depth', type=float, default=1.0, help='Depth of cut in mm')
     parser.add_argument('--feed-rate', type=float, default=100.0, help='Feed rate in mm/min')
@@ -52,6 +52,14 @@ def main():
         strategy = SimpleMilling(
             safe_height=args.safe_height,
             cut_depth=args.cut_depth,
+            feed_rate=args.feed_rate,
+            tool_diameter=args.tool_diameter
+        )
+    elif args.strategy == 'waterline':
+        strategy = WaterlineMilling(
+            safe_height=args.safe_height,
+            step_down=args.cut_depth,
+            total_depth=args.cut_depth,
             feed_rate=args.feed_rate,
             tool_diameter=args.tool_diameter
         )

--- a/tests/test_gcode_generator.py
+++ b/tests/test_gcode_generator.py
@@ -5,6 +5,7 @@ import zipfile
 import tempfile
 from adaptivecad.gcode_generator import generate_gcode_from_ama_file, generate_gcode_from_ama_data
 from adaptivecad.io.ama_reader import AMAFile, AMAPart
+from adaptivecad.io.gcode_generator import ama_to_gcode, WaterlineMilling
 
 class TestGCodeGenerator(unittest.TestCase):
 
@@ -82,6 +83,16 @@ class TestGCodeGenerator(unittest.TestCase):
         """Test G-code generation with a non-existent AMA file path."""
         gcode = generate_gcode_from_ama_file("nonexistent.ama")
         self.assertIsNone(gcode) # Expecting None as the file can't be read
+
+    def test_waterline_strategy(self):
+        """Ensure WaterlineMilling strategy generates a file."""
+        output_gcode_path = os.path.join(self.temp_dir, "waterline.gcode")
+        strategy = WaterlineMilling(step_down=1.0, total_depth=2.0)
+        result_path = ama_to_gcode(self.test_ama_file_path, output_gcode_path, strategy)
+        self.assertTrue(os.path.exists(result_path))
+        with open(result_path, "r") as f:
+            gcode = f.read()
+        self.assertIn("Waterline milling operation", gcode)
 
 if __name__ == '__main__':
     unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
## Summary
- implement `WaterlineMilling` stub strategy
- expose it via `adaptivecad.io`
- allow `ama2gcode.py` to use new strategy
- document stub CAM strategy
- test waterline generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850971a4758832fa34d8a705a83eebf