### PR TITLE
Introduce new constructive and procedural tools

### DIFF
--- a/adaptivecad/commands/__init__.py
+++ b/adaptivecad/commands/__init__.py
@@ -22,6 +22,10 @@ from ..command_defs import (
     NewBallCmd,
     NewTorusCmd,
     NewConeCmd,
+    LoftCmd,
+    SweepAlongPathCmd,
+    ShellCmd,
+    IntersectCmd,
     _require_command_modules,
 )
 
@@ -56,6 +60,10 @@ __all__ = [
     "NewBallCmd",
     "NewTorusCmd",
     "NewConeCmd",
+    "LoftCmd",
+    "SweepAlongPathCmd",
+    "ShellCmd",
+    "IntersectCmd",
     "_require_command_modules",
 ]
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,6 +9,10 @@ def test_commands_import():
     assert hasattr(mod, "NewBoxCmd")
     assert hasattr(mod, "ExportAmaCmd")
     assert hasattr(mod, "RevolveCmd")
+    assert hasattr(mod, "LoftCmd")
+    assert hasattr(mod, "SweepAlongPathCmd")
+    assert hasattr(mod, "ShellCmd")
+    assert hasattr(mod, "IntersectCmd")
 
 
 def test_commands_missing_deps(monkeypatch):


### PR DESCRIPTION
## Summary
- expand command definitions with Loft, Sweep, Shell and Intersect operations
- export new commands via `adaptivecad.commands`
- reorganize playground toolbars into Construct, Procedural and High‑Dim menus
- add Superellipse feature and support new actions in the GUI
- verify imports in tests

## Testing
- `pytest -q` *(fails: numpy/PySide6/OCC not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685152c01ab4832f8e3cff6a5ebe69e0