### PR TITLE
Add mirror modeling tool

### DIFF
--- a/NEW_FEATURES_SUMMARY.md
+++ b/NEW_FEATURES_SUMMARY.md
@@ -138,6 +138,7 @@ Advanced Shapes
 Modeling Tools
 ├── Move
 ├── Scale
+├── Mirror ← NEW
 ├── Union
 ├── Cut
 ├── Intersect
@@ -163,7 +164,7 @@ Help
 ### Enhanced Toolbar
 - Box, Cylinder, Superellipse, Pi Curve Shell
 - **Separator**
-- Move, Union, Cut, **Delete** ← NEW
+- Move, **Mirror** ← NEW, Union, Cut, **Delete** ← NEW
 - All toolbar items have tooltips and icons
 
 ## 7. Technical Implementation
@@ -234,9 +235,10 @@ Help
 
 All requested features have been successfully implemented and tested:
 
-✅ **Delete function** - Fully restored and integrated  
-✅ **Properties window** - Available via Settings > View menu  
+✅ **Delete function** - Fully restored and integrated
+✅ **Properties window** - Available via Settings > View menu
 ✅ **Dimension selector/slicer** - Multi-dimensional view control with ViewCube-like functionality
+✅ **Mirror tool** - Mirror geometry across standard planes
 
 The playground now provides a complete CAD modeling environment with professional-grade features for object management, property editing, and multi-dimensional visualization.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ examples and unit tests without a large toolchain.  Current features include:
 - `adaptivecad.gui.playground` – PySide6 viewer with a rich toolbar for Box,
   Cylinder, Bézier and B‑spline curves, push‑pull editing and export commands
   (STL, AMA and G‑code). The toolbar now offers constructive tools like Move,
-  Scale, Union, Cut, Intersect, Shell plus advanced parametric shapes like
+  Scale, Mirror, Union, Cut, Intersect, Shell plus advanced parametric shapes like
   Superellipse, Pi Curve Shell, Helix, Tapered Cylinder, Capsule and Ellipsoid.
 - Command‑line tools `ama_to_gcode_converter.py` and `ama2gcode.py`
 - Example script `example_script.py` demonstrating curve evaluation

--- a/adaptivecad/gui/playground.py
+++ b/adaptivecad/gui/playground.py
@@ -48,6 +48,7 @@ else:
         CutCmd,
         IntersectCmd,
         ScaleCmd,
+        MirrorCmd,
         NewBallCmd,
         NewTorusCmd,
         NewConeCmd,
@@ -1043,6 +1044,11 @@ class MainWindow:
         scale_action = QAction("Scale", self.win)
         scale_action.triggered.connect(lambda: self._run_command(ScaleCmd()))
         modeling_menu.addAction(scale_action)
+
+        # Add Mirror tool
+        mirror_action = QAction("Mirror", self.win)
+        mirror_action.triggered.connect(lambda: self._run_command(MirrorCmd()))
+        modeling_menu.addAction(mirror_action)
         
         # Add separator
         modeling_menu.addSeparator()
@@ -1157,6 +1163,7 @@ class MainWindow:
         
         # Add common modeling tools to toolbar
         self.toolbar.addAction(move_action)
+        self.toolbar.addAction(mirror_action)
         self.toolbar.addAction(union_action)
         self.toolbar.addAction(cut_action)
         self.toolbar.addAction(delete_action)

--- a/test_new_features.py
+++ b/test_new_features.py
@@ -4,6 +4,7 @@ Test script to verify all new features work correctly in the AdaptiveCAD playgro
 
 Tests:
 - Delete function
+- Mirror tool
 - Properties panel (toggle via Settings > View menu)
 - Dimension selector (toggle via Settings > View menu)
 - Object selection and property editing
@@ -41,6 +42,11 @@ def test_new_features():
         assert hasattr(mw, '_delete_selected'), "Delete function not found"
         
         print("✓ Delete function available")
+
+        # Test mirror command exists
+        from adaptivecad.command_defs import MirrorCmd
+        assert hasattr(MirrorCmd, 'run'), "MirrorCmd not found"
+        print("✓ Mirror command available")
         
         # Test properties panel functions exist
         assert hasattr(mw, '_toggle_properties_panel'), "Properties panel toggle not found"
@@ -143,6 +149,7 @@ if __name__ == "__main__":
         print("\n🎉 All new features are working correctly!")
         print("\nNew Features Added:")
         print("• Delete function - accessible via Modeling Tools menu and toolbar")
+        print("• Mirror tool - mirror selected objects across XY/YZ/XZ")
         print("• Properties Panel - toggle via Settings > View > Show Properties Panel")
         print("• Dimension Selector - toggle via Settings > View > Show Dimension Selector")
         print("• Object Selection - click objects to see properties and edit parameters")


### PR DESCRIPTION
## Summary
- implement `MirrorCmd` for mirroring shapes across XY/YZ/XZ planes
- hook mirror tool into the GUI menu and toolbar
- document new command in `README` and `NEW_FEATURES_SUMMARY`
- adjust feature tests for mirror command

## Testing
- `pytest test_new_features.py -q`
- `pytest test_display_bug_fix.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68515e08075c832f8ba81eb3abaeeb98