### PR TITLE
Add AMA slice export tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ examples and unit tests without a large toolchain.  Current features include:
   Scale, Mirror, Union, Cut, Intersect, Shell plus advanced parametric shapes like
   Superellipse, Pi Curve Shell, Helix, Tapered Cylinder, Capsule and Ellipsoid.
 - Command‑line tools `ama_to_gcode_converter.py` and `ama2gcode.py`
+- Command‑line tool `export_slices.py` for generating BREP or STL slices from an AMA file
 - Example script `example_script.py` demonstrating curve evaluation
 - Unit tests in the `tests` folder (`python -m pytest`)
 

--- a/adaptivecad/__init__.py
+++ b/adaptivecad/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "generate_gcode_from_ama_data",
     "ParamEnv",
     "load_stl",
+    "export_slices_from_ama",
 ]
 
 from .params import ParamEnv
@@ -30,3 +31,9 @@ def load_stl(*args, **kwargs):
     """Convenience wrapper for :func:`simple_stl.load_stl`."""
     from .simple_stl import load_stl as _load_stl
     return _load_stl(*args, **kwargs)
+
+
+def export_slices_from_ama(*args, **kwargs):
+    """Convenience wrapper for :func:`slice_export.export_slices_from_ama`."""
+    from .slice_export import export_slices_from_ama as _export
+    return _export(*args, **kwargs)

--- a/adaptivecad/slice_export.py
+++ b/adaptivecad/slice_export.py
@@ -1,0 +1,77 @@
+"""Utilities to export cross-section slices from AMA files."""
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Iterable
+
+from .io.ama_reader import read_ama
+from .analytic_slicer import slice_brep_for_layer
+
+__all__ = ["export_slices_from_ama"]
+
+
+def export_slices_from_ama(ama_path: str | os.PathLike, z_values: Iterable[float], out_dir: str | os.PathLike = "slices", fmt: str = "brep") -> list[Path]:
+    """Export cross-section slices from an AMA file.
+
+    Parameters
+    ----------
+    ama_path:
+        Path to the AMA file to slice.
+    z_values:
+        Iterable of Z heights to slice at.
+    out_dir:
+        Directory where slice files are written.
+    fmt:
+        Output format: ``"brep"`` or ``"stl"``.
+
+    Returns
+    -------
+    list[Path]
+        List of paths to the generated slice files.
+
+    Notes
+    -----
+    This function requires ``pythonocc-core`` for B-rep operations. If the
+    dependency is missing, :class:`ImportError` will be raised.
+    """
+    try:
+        from OCC.Core.BRep import BRep_Builder
+        from OCC.Core.BRepTools import breptools_Read, breptools_Write
+        from OCC.Core.StlAPI import StlAPI_Writer
+        from OCC.Core.TopoDS import TopoDS_Shape
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise ImportError("pythonocc-core is required for slicing export") from exc
+
+    ama = read_ama(str(ama_path))
+    if not ama or not ama.parts:
+        raise ValueError(f"No parts found in AMA file {ama_path}")
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    results: list[Path] = []
+
+    for part in ama.parts:
+        # Load BREP shape from bytes
+        with tempfile.NamedTemporaryFile(suffix=".brep", delete=False) as tmp:
+            tmp.write(part.brep_data or b"")
+            tmp_path = tmp.name
+        builder = BRep_Builder()
+        shape = TopoDS_Shape()
+        breptools_Read(shape, tmp_path, builder)
+        os.remove(tmp_path)
+
+        for z in z_values:
+            slice_shape = slice_brep_for_layer(shape, float(z))
+            base = f"{part.name}_z{z:g}"
+            if fmt == "stl":
+                path = out_dir / f"{base}.stl"
+                writer = StlAPI_Writer()
+                writer.Write(slice_shape, str(path))
+            else:
+                path = out_dir / f"{base}.brep"
+                breptools_Write(slice_shape, str(path))
+            results.append(path)
+    return results

--- a/export_slices.py
+++ b/export_slices.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Command-line tool to export cross-section slices from an AMA file."""
+from __future__ import annotations
+
+import argparse
+
+from adaptivecad.slice_export import export_slices_from_ama
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export cross-section slices from an AMA file")
+    parser.add_argument("input", help="Input AMA file path")
+    parser.add_argument("heights", nargs="+", type=float, help="Z heights to slice at")
+    parser.add_argument("--out-dir", default="slices", help="Directory to store output slice files")
+    parser.add_argument("--format", choices=["brep", "stl"], default="brep", help="Output file format")
+    args = parser.parse_args()
+
+    export_slices_from_ama(args.input, args.heights, args.out_dir, args.format)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ dependencies = [
     "sympy>=1.13",
 ]
 optional-dependencies = { gui = ["PySide6", "pythonocc-core"] }
+
+[project.scripts]
+export-slices = "export_slices:main"

--- a/tests/test_export_slicing_tool.py
+++ b/tests/test_export_slicing_tool.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.fixture
+def occ_installed():
+    try:
+        import OCC.Core  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def test_export_slices_requires_occ(occ_installed, tmp_path):
+    if occ_installed:
+        pytest.skip("OCC present; this test checks missing dependency")
+
+    from adaptivecad.slice_export import export_slices_from_ama
+
+    with pytest.raises(ImportError):
+        export_slices_from_ama("dummy.ama", [0.0], tmp_path)


### PR DESCRIPTION
## Summary
- implement `adaptivecad.slice_export` for exporting slices from AMA files
- expose a new `export_slices` CLI script
- add wrapper in `adaptivecad.__init__`
- document the tool in the README
- test ImportError behavior when OCC is missing

## Testing
- `pytest -q tests/test_export_slicing_tool.py tests/test_analytic_slicer.py`

------
https://chatgpt.com/codex/tasks/task_e_6852320638dc832faf044ae56557daaa