### PR TITLE
Add spacetime utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ examples and unit tests without a large toolchain.  Current features include:
 - `adaptivecad.gcode_generator` – placeholder G‑code generation routines
   including `SimpleMilling` and a stub `WaterlineMilling` strategy
 - `adaptivecad.analytic_slicer` – helper for analytic B‑rep slicing
+- `adaptivecad.spacetime` – lightweight Minkowski helpers for relativistic experiments
 - `adaptivecad.gui.playground` – PySide6 viewer with a rich toolbar for Box,
   Cylinder, Bézier and B‑spline curves, push‑pull editing and export commands
   (STL, AMA and G‑code). The toolbar now offers constructive tools like Move,
@@ -33,6 +34,14 @@ examples and unit tests without a large toolchain.  Current features include:
 - Command‑line tool `export_slices.py` for generating BREP or STL slices from an AMA file
 - Example script `example_script.py` demonstrating curve evaluation
 - Unit tests in the `tests` folder (`python -m pytest`)
+
+## Spacetime Utilities
+The new `adaptivecad.spacetime` module offers simple Minkowski helpers for
+relativistic experiments:
+
+- `Event` class representing events `(t, x, y, z)`
+- `minkowski_interval` and `apply_boost` for Lorentz transforms
+- `light_cone` sample generator for visualization
 
 
 ## AdaptiveCAD Playground

--- a/adaptivecad/__init__.py
+++ b/adaptivecad/__init__.py
@@ -7,9 +7,22 @@ __all__ = [
     "ParamEnv",
     "load_stl",
     "export_slices_from_ama",
+    # Spacetime helpers
+    "Event",
+    "minkowski_interval",
+    "lorentz_boost_x",
+    "apply_boost",
+    "light_cone",
 ]
 
 from .params import ParamEnv
+from .spacetime import (
+    Event,
+    minkowski_interval,
+    lorentz_boost_x,
+    apply_boost,
+    light_cone,
+)
 
 
 def generate_gcode_from_shape(*args, **kwargs):

--- a/adaptivecad/spacetime.py
+++ b/adaptivecad/spacetime.py
@@ -1,0 +1,77 @@
+"""Basic spacetime utilities for AdaptiveCAD.
+
+This module introduces very small helper classes for 4-D
+Minkowski spacetime. It is intentionally lightweight so that
+other modules can experiment with relativistic concepts such as
+light-cone visualization and Lorentz transformations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Iterable, Tuple
+
+
+@dataclass
+class Event:
+    """A point in Minkowski spacetime with coordinates (t, x, y, z)."""
+
+    t: float
+    x: float
+    y: float
+    z: float
+
+    def as_tuple(self) -> Tuple[float, float, float, float]:
+        return (self.t, self.x, self.y, self.z)
+
+
+def minkowski_interval(e1: Event, e2: Event | None = None) -> float:
+    """Return the squared Minkowski interval between two events."""
+    if e2 is None:
+        e2 = Event(0.0, 0.0, 0.0, 0.0)
+    dt = e1.t - e2.t
+    dx = e1.x - e2.x
+    dy = e1.y - e2.y
+    dz = e1.z - e2.z
+    return dt * dt - (dx * dx + dy * dy + dz * dz)
+
+
+def lorentz_boost_x(beta: float) -> Iterable[Iterable[float]]:
+    """Return a 4x4 Lorentz boost matrix along the x axis.
+
+    Parameters
+    ----------
+    beta:
+        Velocity as a fraction of the speed of light ``v / c``.
+    """
+    if abs(beta) >= 1.0:
+        raise ValueError("beta magnitude must be < 1")
+    gamma = 1.0 / math.sqrt(1.0 - beta * beta)
+    return [
+        [gamma, -gamma * beta, 0.0, 0.0],
+        [-gamma * beta, gamma, 0.0, 0.0],
+        [0.0, 0.0, 1.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+    ]
+
+
+def apply_boost(event: Event, beta: float) -> Event:
+    """Apply an x-axis Lorentz boost to an event."""
+    M = lorentz_boost_x(beta)
+    t = M[0][0] * event.t + M[0][1] * event.x
+    x = M[1][0] * event.t + M[1][1] * event.x
+    return Event(t, x, event.y, event.z)
+
+
+def light_cone(event: Event, radius: float, steps: int = 100) -> Tuple[list[Event], list[Event]]:
+    """Return sample events on the future and past light-cones."""
+    future: list[Event] = []
+    past: list[Event] = []
+    for i in range(steps):
+        phi = 2.0 * math.pi * i / steps
+        x = radius * math.cos(phi)
+        y = radius * math.sin(phi)
+        future.append(Event(event.t + radius, event.x + x, event.y + y, event.z))
+        past.append(Event(event.t - radius, event.x + x, event.y + y, event.z))
+    return future, past

--- a/tests/test_spacetime.py
+++ b/tests/test_spacetime.py
@@ -1,0 +1,18 @@
+from adaptivecad import (
+    Event,
+    minkowski_interval,
+    apply_boost,
+    light_cone,
+)
+
+
+def test_interval_invariance():
+    e = Event(2.0, 1.0, 0.0, 0.0)
+    boosted = apply_boost(e, 0.5)
+    assert abs(minkowski_interval(e) - minkowski_interval(boosted)) < 1e-6
+
+def test_light_cone_counts():
+    e = Event(0.0, 0.0, 0.0, 0.0)
+    future, past = light_cone(e, 1.0, steps=10)
+    assert len(future) == 10
+    assert len(past) == 10


### PR DESCRIPTION
## Summary
- add new `spacetime` module for simple Minkowski geometry
- expose spacetime helpers in package `__init__`
- document spacetime utilities in `README`
- test Lorentz boost invariance

## Testing
- `pytest -q` *(fails: numpy missing)*
- `python -m pytest tests/test_spacetime.py -q` *(fails: numpy missing)*

------
https://chatgpt.com/codex/tasks/task_e_68523f61b538832fafaa2381e8115478