### PR TITLE
Unpack PIA plugin files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+PY ?= python
+.PHONY: pia
+pia:
+	$(PY) examples/pia_constraint_demo/run_pia_demo.py

--- a/blender_addons/adaptivecad_pia/README.md
+++ b/blender_addons/adaptivecad_pia/README.md
@@ -1,0 +1,3 @@
+# Blender Add-on: AdaptiveCAD πₐ Toolpath
+Install via `Edit → Preferences → Add-ons → Install...` and select this folder as a zip.
+Add from `Add → Curve → πₐ Toolpath`. Adjust radius/steps/λ in the operator popup.

--- a/blender_addons/adaptivecad_pia/__init__.py
+++ b/blender_addons/adaptivecad_pia/__init__.py
@@ -1,0 +1,75 @@
+bl_info = {
+    "name": "AdaptiveCAD πₐ Toolpath",
+    "author": "AdaptiveCAD",
+    "version": (0, 1, 0),
+    "blender": (3, 0, 0),
+    "location": "View3D > Add > Curve > πₐ Toolpath",
+    "description": "Generate πₐ-adaptive circle path as a Curve and a Euclidean reference",
+    "category": "Add Curve",
+}
+
+import bpy, math
+from math import pi
+from mathutils import Vector
+
+def trC_xy(x,y):
+    from math import exp
+    g1 = exp(-((x-15)**2 + (y-5)**2)/(2*8**2))
+    g2 = -0.8*exp(-((x+10)**2 + (y+12)**2)/(2*10**2))
+    return 0.6*g1 + 0.6*g2
+
+def generate_points(R0=30.0, N=720, lam_field=0.04):
+    ds = 2*pi*R0 / N
+    theta = 0.0
+    pts = []
+    for k in range(N):
+        x = R0*math.cos(theta); y = R0*math.sin(theta)
+        pts.append((x,y))
+        pia_loc = pi * (1 + lam_field*trC_xy(x,y))
+        dtheta = (pi/pia_loc) * (ds/R0)
+        theta += dtheta
+    pts.append(pts[0])
+    return pts
+
+def make_curve(name, pts, closed=True):
+    curve = bpy.data.curves.new(name=name, type='CURVE')
+    curve.dimensions = '3D'
+    spline = curve.splines.new(type='POLY')
+    spline.points.add(len(pts)-1)
+    for i,(x,y) in enumerate(pts):
+        spline.points[i].co = (x, y, 0.0, 1.0)
+    spline.use_cyclic_u = closed
+    obj = bpy.data.objects.new(name, curve)
+    bpy.context.collection.objects.link(obj)
+    return obj
+
+class ADAPTIVECAD_OT_pia_toolpath(bpy.types.Operator):
+    bl_idname = "adaptivecad.pia_toolpath"
+    bl_label = "Add πₐ Toolpath"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    radius: bpy.props.FloatProperty(name="Radius (mm)", default=30.0, min=1.0, soft_max=200.0)
+    steps:  bpy.props.IntProperty(name="Steps", default=720, min=60, soft_max=2000)
+    lam:    bpy.props.FloatProperty(name="λ (coupling)", default=0.04, min=0.0, soft_max=0.2)
+
+    def execute(self, context):
+        pts = generate_points(self.radius, self.steps, self.lam)
+        obj_pia = make_curve("piA_Path", pts, closed=True)
+        # Euclidean reference circle
+        ref = [(self.radius*math.cos(t), self.radius*math.sin(t)) for t in [2*pi*i/256 for i in range(257)]]
+        obj_ref = make_curve("Euclid_Circle", ref, closed=True)
+        # small bevel for visibility
+        for obj in (obj_pia, obj_ref):
+            obj.data.bevel_depth = 0.2
+        return {'FINISHED'}
+
+def menu_func(self, context):
+    self.layout.operator(ADAPTIVECAD_OT_pia_toolpath.bl_idname, text="πₐ Toolpath", icon='CURVE_DATA')
+
+def register():
+    bpy.utils.register_class(ADAPTIVECAD_OT_pia_toolpath)
+    bpy.types.VIEW3D_MT_curve_add.append(menu_func)
+
+def unregister():
+    bpy.types.VIEW3D_MT_curve_add.remove(menu_func)
+    bpy.utils.unregister_class(ADAPTIVECAD_OT_pia_toolpath)

--- a/examples/pia_constraint_demo/README.md
+++ b/examples/pia_constraint_demo/README.md
@@ -1,0 +1,9 @@
+# πₐ Constraint Tunnel — Demo
+
+Run:
+```bash
+python examples/pia_constraint_demo/run_pia_demo.py --radius 30 --lam 0.04
+```
+Outputs to `examples/pia_constraint_demo/out/`:
+- `pia_toolpath_preview.png` — Euclid vs πₐ path
+- `pia_demo_path.gcode` — G1 polyline toolpath

--- a/examples/pia_constraint_demo/run_pia_demo.py
+++ b/examples/pia_constraint_demo/run_pia_demo.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+πₐ constraint-tunnel demo:
+- Torus πₐ field viz (PNG)
+- Planar πₐ "circle" toolpath vs Euclid (PNG)
+- G-code (G1 polyline) for πₐ path
+"""
+import numpy as np, math, argparse
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+def trC_xy(x,y):
+    g1 = np.exp(-((x-15)**2 + (y-5)**2)/(2*8**2))
+    g2 = -0.8*np.exp(-((x+10)**2 + (y+12)**2)/(2*10**2))
+    return 0.6*g1 + 0.6*g2
+
+def generate_pia_path(R0=30.0, N=720, lam_field=0.04):
+    pi = math.pi
+    ds = 2*pi*R0 / N
+    theta = 0.0
+    xs, ys = [], []
+    for k in range(N):
+        x = R0*math.cos(theta); y = R0*math.sin(theta)
+        xs.append(x); ys.append(y)
+        pia_loc = pi * (1 + lam_field*trC_xy(x,y))
+        dtheta = (pi/pia_loc) * (ds/R0)
+        theta += dtheta
+    xs.append(xs[0]); ys.append(ys[0])
+    return np.array(xs), np.array(ys)
+
+def save_gcode(xs, ys, out_path, feed=1200):
+    lines = ["; π_a demo G-code — adaptive curvature", "G90", "G21", "G0 X0 Y0", f"G1 F{feed}"]
+    for x,y in zip(xs, ys):
+        lines.append(f"G1 X{round(float(x),3)} Y{round(float(y),3)}")
+    Path(out_path).write_text("\n".join(lines)+"\n", encoding="utf-8")
+
+def plot_toolpath(xs, ys, R0, out_png):
+    import numpy as np, matplotlib.pyplot as plt, math
+    t = np.linspace(0, 2*math.pi, 400)
+    plt.figure(figsize=(6,6))
+    plt.plot(R0*np.cos(t), R0*np.sin(t), label="Euclidean circle")
+    plt.plot(xs, ys, label="πₐ-deformed path")
+    plt.axis('equal'); plt.xlabel("X (mm)"); plt.ylabel("Y (mm)"); plt.title("Planar toolpath: πₐ curvature adaptation")
+    plt.legend(); plt.tight_layout(); plt.savefig(out_png, dpi=180); plt.close()
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default=str(Path(__file__).resolve().parent / "out"))
+    ap.add_argument("--radius", type=float, default=30.0)
+    ap.add_argument("--steps", type=int, default=720)
+    ap.add_argument("--lam", type=float, default=0.04)
+    args = ap.parse_args()
+    out = Path(args.out); out.mkdir(parents=True, exist_ok=True)
+    xs, ys = generate_pia_path(args.radius, args.steps, args.lam)
+    save_gcode(xs, ys, out/"pia_demo_path.gcode")
+    plot_toolpath(xs, ys, args.radius, out/"pia_toolpath_preview.png")
+    print("[ok] wrote", out)
+
+if __name__ == "__main__":
+    main()

--- a/freecad/AdaptiveCADPIToolpath/README.md
+++ b/freecad/AdaptiveCADPIToolpath/README.md
@@ -1,0 +1,5 @@
+# FreeCAD Macro: AdaptiveCAD πₐ Toolpath
+Use `Macro → Macros… → Execute` and select `pia_toolpath.py`. It will add two wires:
+- `piA_Path` (πₐ adaptive)
+- `Euclid_Circle` (reference)
+Adjust defaults by editing `run(radius, steps, lam)` at the bottom.

--- a/freecad/AdaptiveCADPIToolpath/pia_toolpath.py
+++ b/freecad/AdaptiveCADPIToolpath/pia_toolpath.py
@@ -1,0 +1,42 @@
+# FreeCAD macro to generate πₐ-adaptive "circle" and Euclidean reference
+import math
+import FreeCAD as App, FreeCADGui as Gui
+import Part
+
+def trC_xy(x,y):
+    g1 = math.exp(-((x-15)**2 + (y-5)**2)/(2*8**2))
+    g2 = -0.8*math.exp(-((x+10)**2 + (y+12)**2)/(2*10**2))
+    return 0.6*g1 + 0.6*g2
+
+def generate_points(R0=30.0, N=720, lam_field=0.04):
+    pi = math.pi
+    ds = 2*pi*R0 / N
+    theta = 0.0
+    pts = []
+    for k in range(N):
+        x = R0*math.cos(theta); y = R0*math.sin(theta)
+        pts.append((x,y))
+        pia_loc = pi * (1 + lam_field*trC_xy(x,y))
+        dtheta = (pi/pia_loc) * (ds/R0)
+        theta += dtheta
+    pts.append(pts[0])
+    return pts
+
+def makeWire(name, pts):
+    vecs = [App.Vector(x,y,0) for (x,y) in pts]
+    w = Part.makePolygon(vecs)
+    obj = App.ActiveDocument.addObject("Part::Feature", name)
+    obj.Shape = w
+    App.ActiveDocument.recompute()
+    return obj
+
+def run(radius=30.0, steps=720, lam=0.04):
+    pts = generate_points(radius, steps, lam)
+    makeWire("piA_Path", pts)
+    ref = [(radius*math.cos(2*math.pi*i/256), radius*math.sin(2*math.pi*i/256)) for i in range(257)]
+    makeWire("Euclid_Circle", ref)
+
+if __name__ == "__main__":
+    if App.ActiveDocument is None: App.newDocument()
+    run()
+    Gui.SendMsgToActiveView("ViewFit")


### PR DESCRIPTION
## Summary
- unpack AdaptiveCAD_pia_plugin_v1.zip and add demo, Blender add-on, and FreeCAD macro
- include Makefile helper for running the PiA demo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689c0cf91b60832fb375f9ee57601dcd