### PR TITLE
Add GitHub Sponsors badge and funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: RDM3DC

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Adaptive Compression Suite (ACS)
 
+[![Sponsor RDM3DC](https://img.shields.io/badge/Sponsor-RDM3DC-ff69b4?logo=github-sponsors)](https://github.com/sponsors/RDM3DC)
+
 A single repo with **three** distinct compression methods we've developed:
 
 1. **ATC — Adaptive Text Compression** (lossless, text):  


### PR DESCRIPTION
## Summary
- add GitHub Sponsors badge linking to `RDM3DC`
- add `.github/FUNDING.yml` so repo shows Sponsor button

## Testing
- `pytest -q` *(fails: test_cmc_1d_psnr, test_cmc_anchor_coverage)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e4c503e0832f84aea69523749595